### PR TITLE
Fix inconsistent menu font weights

### DIFF
--- a/Begin-Your-Revolution.html
+++ b/Begin-Your-Revolution.html
@@ -76,7 +76,7 @@
 
     .navbar a {
       color: black;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
     }
 

--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
       </div>
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
-      <a href="https://www.youros.app/pricing-competitors" style="font-weight:700;">Pricing & Competitors</a>
+      <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
     </div>
   </nav>
 

--- a/lets-talk-ai.html
+++ b/lets-talk-ai.html
@@ -124,7 +124,7 @@
 
     .navbar a {
       color: black;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
     }
 

--- a/pricing-competitors.html
+++ b/pricing-competitors.html
@@ -88,7 +88,7 @@
 
     .navbar a {
       color: black;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
     }
 

--- a/security-trust.html
+++ b/security-trust.html
@@ -91,7 +91,7 @@
 
     .navbar a {
       color: black;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
     }
 

--- a/what-does-youros-do/index.html
+++ b/what-does-youros-do/index.html
@@ -333,7 +333,7 @@
       </div>
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
-      <a href="https://www.youros.app/pricing-competitors" style="font-weight:700;">Pricing & Competitors</a>
+      <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/hvac.html
+++ b/what-does-youros-do/stories-and-testimony/hvac.html
@@ -76,6 +76,9 @@
       align-items: center;
       gap: 1.5rem;
     }
+    .nav-links a {
+      font-weight: 500;
+    }
 
     .nav-toggle {
       display: none;
@@ -337,7 +340,7 @@
       </div>
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
-      <a href="https://www.youros.app/pricing-competitors" style="font-weight:700;">Pricing & Competitors</a>
+      <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/index.html
+++ b/what-does-youros-do/stories-and-testimony/index.html
@@ -363,7 +363,7 @@
       </div>
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
-      <a href="https://www.youros.app/pricing-competitors" style="font-weight:700;">Pricing & Competitors</a>
+      <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/vehicle-track-to-backlog.html
+++ b/what-does-youros-do/stories-and-testimony/vehicle-track-to-backlog.html
@@ -250,7 +250,7 @@
 
     .navbar a {
       color: black;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
     }
 

--- a/what-does-youros-do/stories-and-testimony/where-it-started.html
+++ b/what-does-youros-do/stories-and-testimony/where-it-started.html
@@ -88,7 +88,7 @@
 
     .navbar a {
       color: black;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
     }
 

--- a/what-does-youros-do/stories-and-testimony/whiteboard.html
+++ b/what-does-youros-do/stories-and-testimony/whiteboard.html
@@ -88,7 +88,7 @@
 
     .navbar a {
       color: black;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
     }
 

--- a/youros-home.html
+++ b/youros-home.html
@@ -319,7 +319,7 @@
       </div>
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
-      <a href="https://www.youros.app/pricing-competitors" style="font-weight:700;">Pricing & Competitors</a>
+      <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
     </div>
   </nav>
 


### PR DESCRIPTION
## Summary
- make global menu links consistent
- keep menu font weight uniform across all pages

## Testing
- `grep -R "style=\"font-weight:700" -n`


------
https://chatgpt.com/codex/tasks/task_e_6866bbf65b1c83288dc86a84a063c8bf