### PR TITLE
Fix hvac nav link color

### DIFF
--- a/what-does-youros-do/stories-and-testimony/hvac.html
+++ b/what-does-youros-do/stories-and-testimony/hvac.html
@@ -79,6 +79,7 @@
     }
     .nav-links a {
       font-weight: 500;
+      color: black;
     }
 
     .nav-toggle {


### PR DESCRIPTION
## Summary
- keep nav links black on the HVAC page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fdb3c33b08328b637fd621b78a0b8