### PR TITLE
Add hidden blog link in nav

### DIFF
--- a/Begin-Your-Revolution.html
+++ b/Begin-Your-Revolution.html
@@ -285,6 +285,7 @@
       </div>
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/blog/first-post/index.html
+++ b/blog/first-post/index.html
@@ -347,6 +347,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -366,6 +366,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/index.html
+++ b/index.html
@@ -347,6 +347,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/lets-talk-ai.html
+++ b/lets-talk-ai.html
@@ -343,6 +343,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/pricing-competitors.html
+++ b/pricing-competitors.html
@@ -279,6 +279,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/security-trust.html
+++ b/security-trust.html
@@ -343,6 +343,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/index.html
+++ b/what-does-youros-do/index.html
@@ -335,6 +335,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/hvac.html
+++ b/what-does-youros-do/stories-and-testimony/hvac.html
@@ -343,6 +343,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/index.html
+++ b/what-does-youros-do/stories-and-testimony/index.html
@@ -421,6 +421,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/vehicle-track-to-backlog.html
+++ b/what-does-youros-do/stories-and-testimony/vehicle-track-to-backlog.html
@@ -345,6 +345,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/where-it-started.html
+++ b/what-does-youros-do/stories-and-testimony/where-it-started.html
@@ -322,6 +322,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/what-does-youros-do/stories-and-testimony/whiteboard.html
+++ b/what-does-youros-do/stories-and-testimony/whiteboard.html
@@ -343,6 +343,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 

--- a/youros-home.html
+++ b/youros-home.html
@@ -347,6 +347,7 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
+      <a href="/blog/" style="color:white">Blog</a>
     </div>
   </nav>
 


### PR DESCRIPTION
## Summary
- add Blog link to nav menus across the site
- style the link in white so it's currently hidden

## Testing
- `git diff --cached --stat`


------
https://chatgpt.com/codex/tasks/task_e_687195a3eab88328b8086da72e0d0e75