### PR TITLE
Make blog index show four posts per row

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -264,7 +264,7 @@
 
     .posts-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
       gap: 2rem;
     }
 


### PR DESCRIPTION
## Summary
- adjust post grid min column width so four cards fit on wide screens

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6871cbdf99c08328af3a5d2d61521dbe