### PR TITLE
Remove stray codex text from blog pages

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -381,7 +381,6 @@
   <section class="section wrapper posts-grid">
     <article class="post-card">
       <h2><a href="/blog/software-adoption-secret/">The Software Adoption Secret</a></h2>
-      u8mdou-codex/update-blog-post-and-slug-for-software-adoption-secret
       <p class="muted">July 12, 2025 — Logistics</p>
       <p>Feel like no on is using the system right? Discover our game-changing secret to user adoption that transforms frustration into success. Learn why at Your OS, we found the perfect harmony between user and stakeholder—unlocking productivity, boosting morale, and delivering software your team WANTS to use.</p>
 

--- a/blog/software-adoption-secret/index.html
+++ b/blog/software-adoption-secret/index.html
@@ -355,7 +355,6 @@
   <!-- BLOG POST -->
   <section class="hero">
     <h1>Software Adoption Secret</h1>
-u8mdou-codex/update-blog-post-and-slug-for-software-adoption-secret
     <p class="muted">July 12, 2025 — Logistics</p>
 
   </section>


### PR DESCRIPTION
## Summary
- remove codex placeholder from blog post listing
- remove codex placeholder from the Software Adoption Secret post

## Testing
- `grep -n "u8mdou" -r blog`


------
https://chatgpt.com/codex/tasks/task_e_68743103ad5883288f5df2dba0983df5