### PR TITLE
Add line breaks before blog headers

### DIFF
--- a/blog/software-adoption-secret/index.html
+++ b/blog/software-adoption-secret/index.html
@@ -354,47 +354,47 @@
 
   <!-- BLOG POST -->
   <section class="hero">
-    <h1>The Software Adoption Secret</h1>
+    <br><h1>The Software Adoption Secret</h1>
     <p class="muted">July 12, 2025 — Logistics</p>
 
   </section>
 
   <section class="section wrapper">
-    <h2>The User Adoption Secret! We Ask he Users!</h2>
+    <br><h2>The User Adoption Secret! We Ask he Users!</h2>
 
     <p>Executives, upper-level managers, let’s be brutally honest: Your current systems are probably not being used they way they were designed. Maybe you know it outright, or perhaps you're quietly feeling it every day as productivity stalls, user frustration rises, and your carefully planned software initiatives fall short. These frustrations manifest in countless wasted hours, escalating complaints, and declining morale. You've tried quick fixes, patches, or trainings that never really solved the root problems and asking the designers to make a simple change that would help immensely. Here’s the problem: traditional software design approaches have a fatal flaw. They place stakeholders front and center, bypassing the invaluable gold mine of insights from the actual users, the very individuals who experience firsthand all pain points, bottlenecks, and daily inefficiencies that cripple productivity and stifle innovation.</p>
 
 
-    <h2>Why Software Systems Usually Fail</h2>
+    <br><h2>Why Software Systems Usually Fail</h2>
     <p>In our years of working with ambitious, driven leaders, we've seen a recurring pattern. A new system initiative kicks off. Stakeholders who are typically the check-signers, budget holders, and department heads, list their requirements, detailing their imagined scenarios of seamless adoption and productivity boosts. And why wouldn't they? After all, stakeholders have clear ideas about their ideal world. Unfortunately, these ideas are often divorced from the day-to-day realities users face.</p>
     <p>Here's the harsh truth: When stakeholders define software, they focus on their own pain points, which is fine. It's just often centered around reporting, oversight, or simplified management. While important, these concerns frequently overshadow the real, ground-level challenges faced by end-users. Thus, the software built may make life easier for the people not really using it, and harder for users, the very people whose adoption determines success or failure.</p>
     <p>Often, stakeholders' visions are shaped by abstract concepts and ideal conditions rather than practical, everyday situations. These idealized scenarios typically ignore complex, unforeseen factors that arise naturally during actual use. As a result, systems designed without substantial user input become riddled with cumbersome workflows, missing features, and misaligned priorities, severely complexing user efficiency and satisfaction.</p>
 
-    <h2>The User Knows Best</h2>
+    <br><h2>The User Knows Best</h2>
     <p>The solution? Going straight to the users and asking them.</p>
     <p>In our extensive experience developing systems hundreds of times over, we have found consistently that users come pre-loaded with incredible insights. Before we even pose a question, users are bursting with ideas to fix or enhance their current systems. They often carry a detailed mental inventory of what's missing, the small annoyances, and the larger frustrations that interrupt their workflow daily. Users intimately understand how inefficiencies ripple outwards, impacting their productivity, job satisfaction, and ultimately the organization's bottom line.</p>
     <p>Imagine this common scenario we've encountered repeatedly: stakeholders enthusiastically present a newly developed system. They're excited, confident, expecting applause. They've invested significant resources, time, and energy into what they believe is an ideal solution. Yet, within moments, users identify critical gaps, flaws, and necessary changes that were missed entirely. They point out practical issues such as bad navigation, overlooked crucial functionalities, or features that seem beneficial in theory but are impractical in the real-world. Everyone is left shocked, users become frustrated, and executives find themselves facing unexpected hurdles.</p>
     <p>Moreover, engaging users early and frequently cultivates a deeper sense of ownership and investment in the new system. They don’t just identify problems, they proactively suggest highly specific and practical solutions, often minor adjustments or straightforward tweaks that significantly enhance functionality and user-friendliness. Leveraging these detailed, actionable insights generates a powerful feedback loop, fueling continuous refinement and improvement. This virtuous cycle not only elevates user satisfaction but significantly boosts overall productivity, efficiency, and innovation across the organization, leading to sustainable, long-term success.</p>
 
-    <h2>Having Your Cake and Eating it Too — Your Operating System’s Difference</h2>
+    <br><h2>Having Your Cake and Eating it Too — Your Operating System’s Difference</h2>
     <p>At Your Operating System (Your OS), we don't just acknowledge this gap, we live for it! Our mission is straightforward: "Give ambitious people control so that they can see with clarity, be home early, and always win at work."</p>
     <p>We achieve this by prioritizing user feedback from day one. Unlike traditional approaches, we don't simply hand over all decisions to be made how it works to stakeholders. Instead, we engage directly with users, mining their detailed, actionable insights, and weaving these into the fabric of our systems. The result? Software that users embrace enthusiastically, because it genuinely reflects their real-world workflows, challenges, and needs!</p>
 
     <p>But here's where Your OS really shines: we don’t neglect stakeholders. Rather, we integrate their requirements effortlessly by understanding that improved user experience inherently leads to clearer insights, better reporting, and enhanced metrics, which is exactly what stakeholders crave. When users are empowered and happy, stakeholders get their desired visibility and control organically.</p>
     <p>Our approach is holistic. It connects user experience directly to stakeholder satisfaction, creating harmony across all organizational levels. This integrated strategy ensures that everyone wins: users gain systems that simplify and enhance their daily tasks, and stakeholders receive accurate, real-time insights into team performance and productivity.</p>
 
-    <h2>It’s Not Just Theory — It’s Proven Practice</h2>
+    <br><h2>It’s Not Just Theory — It’s Proven Practice</h2>
     <p>This isn't speculation or just wishful thinking. In literally hundreds of personal experiences guiding teams toward user-focused solutions, we've consistently seen the dramatic uptick in adoption and effectiveness that comes from prioritizing user insights.</p>
     <p>For instance, consider a scenario from our experience (names withheld, of course): a large organization had invested significantly in software upgrades, only to find their users resistant and unproductive. Frustrated and confused, the stakeholders couldn't pinpoint what had gone wrong. After all, they had carefully described their ideal system when searching for a solution!</p>
     <p>When we stepped in, the first step wasn't another stakeholder meeting. Instead, we sat down with users, asked pointed questions, and listened. Within hours, we unearthed fundamental mismatches between stakeholder visions and user realities. Changes were swiftly made based on direct user feedback, and within weeks, adoption soared, productivity climbed, and stakeholders finally gained the clarity they'd always sought.</p>
     <p>We've witnessed countless similar success stories, each underscoring the undeniable value of placing users at the heart of software development. The numbers speak volumes: higher adoption rates, increased efficiency, improved morale, and measurable gains in overall performance.</p>
 
-    <h2>Don’t Settle — Demand Better Software</h2>
+    <br><h2>Don’t Settle — Demand Better Software</h2>
     <p>Executives and managers: you're not wrong to expect better. Your current systems probably aren't serving your organization's full potential. But it doesn't have to be this way. Software doesn’t have to be a burdensome, disappointing compromise. There's a better approach, a fundamentally different paradigm.</p>
     <p>At Your Operating System, we believe that those who could excel, should excel. It’s our core belief, shaping every decision and approach we take. Software, finally, can fulfill its promise and truly work for you and not the other way around.</p>
     <p>We understand if this sounds radical. After all, traditional stakeholder-focused development is deeply entrenched. But remember: just because something is mainstream doesn't mean it's optimal. The greener grass isn't just wishful thinking. It's a reality we've repeatedly delivered.</p>
 
-    <h2>Ready for Systems that Actually Work? Call Your OS.</h2>
+    <br><h2>Ready for Systems that Actually Work? Call Your OS.</h2>
     <p>Your systems deserve better. Your users demand better. Your stakeholders expect better.</p>
     <p>Together, let's build Your Systems the way you want them to work.</p>
   </section>


### PR DESCRIPTION
## Summary
- improve readability of the Software Adoption Secret blog post by inserting line breaks before each header

## Testing
- `grep -n "<br><h" blog/software-adoption-secret/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6876898fea348328816c79190caf6c9b