### PR TITLE
Add 5 SEO money pages

### DIFF
--- a/ai-assistants-for-business/index.html
+++ b/ai-assistants-for-business/index.html
@@ -15,7 +15,7 @@
     body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
     a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
     h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
-    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding-top:4rem;padding-bottom:4rem;}p+p{margin-top:1rem;}
     nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
     .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
     .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
@@ -68,70 +68,70 @@
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">AI Assistants for Business</div>
-    <h1>Custom AI Assistants for Business Workflows, Not AI Theater</h1>
-    <p>We build AI sidekicks that help your team summarize, draft, route, search, and act inside the systems your business actually uses — grounded in real data, not hallucinated context.</p>
-    <a class="cta" href="/Begin-Your-Revolution.html">See What an AI Sidekick Could Do for You</a>
+    <div class="hero-eyebrow">Custom AI Assistants for Business</div>
+    <h1>Your Team Does Hours of Low-Value Knowledge Work Every Day. AI-Powered Assistants Handle That Instead.</h1>
+    <p>We build custom AI assistants that work inside the systems your business actually uses — AI-powered sidekicks grounded in your real data, your real workflows, and your real operations. Not AI theater. Not hallucinated answers. Practical AI that earns its place.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">See What an AI Sidekick Does for You</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › AI Assistants for Business</div>
-    <h2>What an AI assistant can do for a business</h2>
-    <p>The right AI assistant handles the low-value knowledge work your team does every day — so they can focus on the work that actually needs a human.</p>
+    <h2>What a custom AI assistant handles instead of your team</h2>
+    <p>The right AI-powered assistant takes the repetitive, low-value knowledge work off your team's plate — so they spend their hours on the work that actually needs a human brain behind it.</p>
     <ul class="check-list">
-      <li>Summarize job updates, ticket history, or customer threads in seconds</li>
-      <li>Draft responses, follow-ups, and status reports automatically</li>
-      <li>Answer internal questions from your own data, SOPs, and records</li>
-      <li>Prepare weekly reports without anyone building them manually</li>
-      <li>Spot missing information before it causes a problem downstream</li>
-      <li>Route incoming requests to the right person or queue without manual triage</li>
+      <li>AI-powered job update and customer thread summaries — in seconds, not 20 minutes of reading</li>
+      <li>AI-drafted responses, follow-ups, and status reports — ready to review and send, not built from scratch</li>
+      <li>AI-answered internal questions from your own data, SOPs, and records — not guesses from the open internet</li>
+      <li>AI-prepared weekly reports — generated and delivered automatically, no manual building required</li>
+      <li>AI-spotted missing information — flagged before it causes a downstream problem, not after</li>
+      <li>AI-managed request routing — incoming work assigned to the right person or queue without manual triage</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>Where AI assistants fail without a system behind them</h2>
-      <p>Most AI implementations fail not because the AI is bad — but because the foundation isn't there. AI amplifies what's already in your data. If the data is messy, the AI output is too.</p>
+      <h2>Why most AI assistant deployments fail — and what we do differently</h2>
+      <p>Most AI implementations fail not because the AI is bad — but because the foundation isn't there. AI amplifies what's already in your data. If the data is messy, the AI output will be messier. If the process is broken, AI accelerates the chaos.</p>
       <ul class="warning-list">
-        <li>Bad data — garbage in, garbage out. AI needs clean, structured information to work from.</li>
-        <li>Unclear processes — AI can't automate a workflow nobody has defined</li>
-        <li>No permissions model — AI acting on uncontrolled data creates risk, not efficiency</li>
-        <li>No source of truth — AI will hallucinate when it can't find a clear answer</li>
-        <li>No human approval layer — unsupervised AI actions compound mistakes fast</li>
+        <li>Bad data — garbage in, garbage out. AI-powered assistants need clean, structured data or they make things up.</li>
+        <li>Undefined processes — AI-powered automation can't run a workflow nobody has clearly defined yet</li>
+        <li>No permissions model — AI acting on uncontrolled data creates liability and risk, not efficiency</li>
+        <li>No source of truth — AI will hallucinate confidently when it can't find a real, grounded answer</li>
+        <li>No human approval layer — unsupervised AI-powered actions compound mistakes faster than humans can</li>
       </ul>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>Why YourOS builds the system first</h2>
-    <p>We don't drop an AI assistant on top of a broken process. We fix the foundation, then add AI where it genuinely saves time.</p>
+    <h2>Why YourOS builds the AI-ready foundation first</h2>
+    <p>We don't drop an AI-powered assistant on top of a broken process. We build the clean system underneath it first — then add AI where it genuinely multiplies your team's output.</p>
     <ul class="check-list">
-      <li>Clean data — structured inputs, validated fields, one source of truth</li>
-      <li>Clear workflow — every step defined before AI touches any of it</li>
-      <li>Controlled actions — AI suggests, humans approve where it matters</li>
-      <li>Grounded answers — AI pulls from your actual records, not the open internet</li>
+      <li>AI-ready clean data — structured inputs, validated fields, one source of AI-accessible truth</li>
+      <li>Clearly defined AI-enhanced workflow — every step mapped and confirmed before AI is layered on</li>
+      <li>AI-suggested, human-approved actions — AI recommends, humans decide where consequences are real</li>
+      <li>AI grounded in your actual records — pulls from your AppSheet systems and real data, not the open internet</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>AI sidekick examples we build</h2>
+      <h2>AI-powered sidekicks we build for real business workflows</h2>
       <div class="grid">
-        <div class="card"><h3>Operations Sidekick</h3><p>Monitors job status, flags overdue items, summarizes daily activity — so the ops manager doesn't have to chase everything manually.</p></div>
-        <div class="card"><h3>Sales Follow-up Sidekick</h3><p>Drafts follow-up messages, tracks where each lead stands, and reminds the team before opportunities go cold.</p></div>
-        <div class="card"><h3>Reporting Sidekick</h3><p>Pulls data from your AppSheet system and generates formatted summaries — weekly, daily, or on demand.</p></div>
-        <div class="card"><h3>Customer Intake Sidekick</h3><p>Parses incoming requests, extracts key information, routes to the right team, and drafts the first response.</p></div>
-        <div class="card"><h3>Admin Sidekick</h3><p>Handles scheduling questions, document lookups, and internal FAQ — freeing up admin staff for higher-value work.</p></div>
-        <div class="card"><h3>Field Team Sidekick</h3><p>Gives field staff instant access to job history, customer notes, and SOPs from mobile — no digging through emails or spreadsheets.</p></div>
+        <div class="card"><h3>AI-Powered Operations Sidekick</h3><p>AI monitors job status, flags overdue items, and summarizes daily activity — so the ops manager focuses on fixing problems, not finding them.</p></div>
+        <div class="card"><h3>AI-Driven Sales Follow-up Sidekick</h3><p>AI drafts follow-up messages, tracks where each lead stands, and alerts the team before opportunities go cold and stay there.</p></div>
+        <div class="card"><h3>AI-Generated Reporting Sidekick</h3><p>AI pulls live data from your AppSheet system and generates formatted summaries — weekly, daily, or the moment you ask.</p></div>
+        <div class="card"><h3>AI-Powered Customer Intake Sidekick</h3><p>AI parses incoming requests, extracts what matters, routes to the right team, and drafts the first response — faster than any human triage.</p></div>
+        <div class="card"><h3>AI-Enhanced Admin Sidekick</h3><p>AI handles scheduling questions, document lookups, and internal FAQ — freeing admin staff for the work that actually needs a person.</p></div>
+        <div class="card"><h3>AI-Assisted Field Team Sidekick</h3><p>AI gives field staff instant mobile access to job history, customer notes, and SOPs — no digging through old emails or broken spreadsheets.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>See What an AI Sidekick Could Do in Your Workflow</h2>
-      <p>We'll map the manual knowledge work your team does every day and show you where an AI assistant would actually save time — and where it wouldn't.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+      <h2>Find Out Where an AI-Powered Sidekick Would Save Your Team the Most Time</h2>
+      <p>We'll map the low-value knowledge work your team does every day, identify exactly where AI-powered automation would save the most hours, and show you what a working AI assistant looks like in your workflow.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free AI Workflow Audit</a>
     </div>
     <div class="internal-links">
       <a href="/ai-automation-services-small-business/">AI Automation Services →</a>

--- a/ai-assistants-for-business/index.html
+++ b/ai-assistants-for-business/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Custom AI Assistants for Business Workflows | YourOS</title>
+  <meta name="description" content="We build AI sidekicks that help your team summarize, draft, route, search, and act inside the systems your business actually uses. Practical AI, not AI theater." />
+  <link rel="canonical" href="https://www.youros.app/ai-assistants-for-business/" />
+  <meta name="robots" content="index, follow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#1c1c1e;--bg-alt:#2a2a2a;--primary:#0077ff;--primary-light:#00afff;--action:#f97316;--action-hover:#ea580c;--text:#e6e8ec;--muted:#9ca3af;--chrome:linear-gradient(135deg,#cfd4d9 0%,#9ea3a6 100%);--white:#fff;--black:#111;}
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
+    a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
+    h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
+    .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
+    .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
+    .nav-links a{text-decoration:none;color:var(--black);font-weight:500;}.nav-links a:hover{color:var(--primary);}
+    .nav-cta-link{background:var(--action);color:var(--white)!important;padding:0.5rem 1.1rem;border-radius:6px;font-weight:600!important;font-size:0.9rem;transition:background .2s;}.nav-cta-link:hover{background:var(--action-hover)!important;color:var(--white)!important;}
+    .dropdown{position:relative;}.dropdown-content{display:none;position:absolute;top:100%;left:0;background:var(--white);min-width:220px;box-shadow:0 4px 8px rgba(0,0,0,.1);z-index:999;border-radius:4px;}
+    .dropdown-content a{display:block;padding:0.75rem 1rem;color:var(--black);font-size:0.9rem;}.dropdown-content a:hover{background:#f2f2f2;color:var(--primary);}.dropdown:hover .dropdown-content{display:block;}
+    .hero{background:radial-gradient(circle at center,rgba(249,115,22,.08) 0%,transparent 70%);padding:6rem 1.5rem 5rem;text-align:center;}
+    .hero-eyebrow{display:inline-block;background:rgba(249,115,22,.12);border:1px solid rgba(249,115,22,.3);color:var(--action);font-size:0.8rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;padding:0.35rem 1rem;border-radius:999px;margin-bottom:1.5rem;}
+    .hero h1{background:var(--chrome);-webkit-background-clip:text;color:transparent;max-width:820px;margin:0 auto 1.25rem;}
+    .hero p{font-size:1.15rem;max-width:640px;margin:0 auto;color:var(--muted);}
+    .cta{display:inline-block;background:var(--action);color:#fff;padding:1rem 2.25rem;border-radius:8px;box-shadow:0 0 12px rgba(249,115,22,.35);transition:transform .2s,box-shadow .2s;font-weight:700;margin-top:2rem;}
+    .cta:hover{background:var(--action-hover);color:#fff;transform:translateY(-2px);box-shadow:0 0 20px rgba(249,115,22,.5);}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem;margin-top:2rem;}
+    .card{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:1.5rem;}.card h3{font-size:1rem;margin-bottom:0.5rem;}.card p{font-size:0.9rem;color:var(--muted);}
+    .check-list{list-style:none;margin-top:1.25rem;}.check-list li{padding:0.5rem 0;border-bottom:1px solid rgba(255,255,255,.06);font-size:0.95rem;display:flex;align-items:flex-start;gap:0.6rem;}.check-list li::before{content:"✓";color:var(--action);font-weight:700;flex-shrink:0;}
+    .warning-list{list-style:none;margin-top:1.25rem;}.warning-list li{padding:0.5rem 0;border-bottom:1px solid rgba(255,255,255,.06);font-size:0.95rem;display:flex;align-items:flex-start;gap:0.6rem;}.warning-list li::before{content:"✗";color:#f87171;font-weight:700;flex-shrink:0;}
+    .cta-block{background:rgba(249,115,22,.07);border:1px solid rgba(249,115,22,.2);border-radius:16px;padding:3.5rem 2rem;text-align:center;}.cta-block h2{margin-bottom:0.75rem;}.cta-block p{color:var(--muted);max-width:520px;margin:0 auto 2rem;}
+    .internal-links{display:flex;flex-wrap:wrap;gap:0.75rem;margin-top:2rem;}.internal-links a{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:0.5rem 1rem;font-size:0.85rem;color:var(--text);font-weight:400;}.internal-links a:hover{border-color:var(--action);color:var(--action);}
+    .breadcrumb{font-size:0.85rem;color:var(--muted);padding:1rem 0;}.breadcrumb a{color:var(--muted);font-weight:400;}.breadcrumb a:hover{color:var(--text);}
+    footer{text-align:center;background:var(--bg-alt);padding:2rem 1.5rem;font-size:.9rem;color:var(--muted);}
+    .favicon-footer{position:fixed;bottom:20px;right:20px;width:32px;height:32px;opacity:0.8;}
+    @media(max-width:768px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;}.nav-links.open{display:flex;}.nav-toggle{display:block;}}
+    @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+  </style>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
+</head>
+<body>
+  <nav>
+    <a class="nav-left" href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Logo"><span>YOUR Operating System</span></a>
+    <button class="nav-toggle" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+    <div class="nav-links">
+      <a href="https://www.youros.app/youros-home">YourOS Home</a>
+      <div class="dropdown"><a href="#">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="/ai-automation-services-small-business/">AI Automation Services</a>
+          <a href="/custom-workflow-automation/">Custom Workflow Automation</a>
+          <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets</a>
+          <a href="/appsheet-consultant/">AppSheet Consulting</a>
+          <a href="/ai-assistants-for-business/">AI Assistants for Business</a>
+        </div>
+      </div>
+      <div class="dropdown"><a href="https://www.youros.app/what-does-youros-do">What Does YourOS Do? ▾</a>
+        <div class="dropdown-content"><a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a></div>
+      </div>
+      <a href="/blog/">Blog</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Workflow Audit</a>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <div class="hero-eyebrow">AI Assistants for Business</div>
+    <h1>Custom AI Assistants for Business Workflows, Not AI Theater</h1>
+    <p>We build AI sidekicks that help your team summarize, draft, route, search, and act inside the systems your business actually uses — grounded in real data, not hallucinated context.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">See What an AI Sidekick Could Do for You</a>
+  </section>
+
+  <section class="section wrapper">
+    <div class="breadcrumb"><a href="/">Home</a> › AI Assistants for Business</div>
+    <h2>What an AI assistant can do for a business</h2>
+    <p>The right AI assistant handles the low-value knowledge work your team does every day — so they can focus on the work that actually needs a human.</p>
+    <ul class="check-list">
+      <li>Summarize job updates, ticket history, or customer threads in seconds</li>
+      <li>Draft responses, follow-ups, and status reports automatically</li>
+      <li>Answer internal questions from your own data, SOPs, and records</li>
+      <li>Prepare weekly reports without anyone building them manually</li>
+      <li>Spot missing information before it causes a problem downstream</li>
+      <li>Route incoming requests to the right person or queue without manual triage</li>
+    </ul>
+  </section>
+
+  <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2>Where AI assistants fail without a system behind them</h2>
+      <p>Most AI implementations fail not because the AI is bad — but because the foundation isn't there. AI amplifies what's already in your data. If the data is messy, the AI output is too.</p>
+      <ul class="warning-list">
+        <li>Bad data — garbage in, garbage out. AI needs clean, structured information to work from.</li>
+        <li>Unclear processes — AI can't automate a workflow nobody has defined</li>
+        <li>No permissions model — AI acting on uncontrolled data creates risk, not efficiency</li>
+        <li>No source of truth — AI will hallucinate when it can't find a clear answer</li>
+        <li>No human approval layer — unsupervised AI actions compound mistakes fast</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <h2>Why YourOS builds the system first</h2>
+    <p>We don't drop an AI assistant on top of a broken process. We fix the foundation, then add AI where it genuinely saves time.</p>
+    <ul class="check-list">
+      <li>Clean data — structured inputs, validated fields, one source of truth</li>
+      <li>Clear workflow — every step defined before AI touches any of it</li>
+      <li>Controlled actions — AI suggests, humans approve where it matters</li>
+      <li>Grounded answers — AI pulls from your actual records, not the open internet</li>
+    </ul>
+  </section>
+
+  <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2>AI sidekick examples we build</h2>
+      <div class="grid">
+        <div class="card"><h3>Operations Sidekick</h3><p>Monitors job status, flags overdue items, summarizes daily activity — so the ops manager doesn't have to chase everything manually.</p></div>
+        <div class="card"><h3>Sales Follow-up Sidekick</h3><p>Drafts follow-up messages, tracks where each lead stands, and reminds the team before opportunities go cold.</p></div>
+        <div class="card"><h3>Reporting Sidekick</h3><p>Pulls data from your AppSheet system and generates formatted summaries — weekly, daily, or on demand.</p></div>
+        <div class="card"><h3>Customer Intake Sidekick</h3><p>Parses incoming requests, extracts key information, routes to the right team, and drafts the first response.</p></div>
+        <div class="card"><h3>Admin Sidekick</h3><p>Handles scheduling questions, document lookups, and internal FAQ — freeing up admin staff for higher-value work.</p></div>
+        <div class="card"><h3>Field Team Sidekick</h3><p>Gives field staff instant access to job history, customer notes, and SOPs from mobile — no digging through emails or spreadsheets.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <div class="cta-block">
+      <h2>See What an AI Sidekick Could Do in Your Workflow</h2>
+      <p>We'll map the manual knowledge work your team does every day and show you where an AI assistant would actually save time — and where it wouldn't.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+    </div>
+    <div class="internal-links">
+      <a href="/ai-automation-services-small-business/">AI Automation Services →</a>
+      <a href="/custom-workflow-automation/">Custom Workflow Automation →</a>
+      <a href="/appsheet-consultant/">AppSheet Consulting →</a>
+    </div>
+  </section>
+
+  <footer>© 2025 YourOS. Those who could excel, should excel.</footer>
+  <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
+  <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
+</body>
+</html>

--- a/ai-automation-services-small-business/index.html
+++ b/ai-automation-services-small-business/index.html
@@ -23,7 +23,7 @@
     h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}
     h2{font-size:2rem;}h3{font-size:1.25rem;}
     .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}
-    .section{padding:4rem 0;}
+    .section{padding-top:4rem;padding-bottom:4rem;}
     p+p{margin-top:1rem;}
     nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
     .nav-left{display:flex;align-items:center;gap:0.75rem;}
@@ -102,71 +102,71 @@
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">AI Automation Services</div>
-    <h1>AI Automation Services for Small Businesses That Are Tired of Repetitive Work</h1>
-    <p>We find the manual steps slowing your team down, then build practical AI automations and workflows around how your business already works.</p>
-    <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+    <div class="hero-eyebrow">AI-Powered Automation Services</div>
+    <h1>Your Team Is Spending 8+ Hours a Week on Work AI Can Eliminate</h1>
+    <p>We audit your workflow, identify exactly what AI can take off your team's plate, and build practical AI-powered automation systems around how your business actually runs — fast.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Get Your Free AI Workflow Audit</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › AI Automation Services</div>
-    <h2>Signs your business is ready for AI automation</h2>
-    <p>If your team is doing any of these things regularly, you're losing hours every week to work a system could be doing instead.</p>
+    <h2>Warning signs your business is paying for human labor AI should be doing</h2>
+    <p>Every item below represents real dollars — paid labor spent on repetitive work an AI-powered system would handle in the background, automatically, without anyone thinking about it.</p>
     <ul class="check-list">
-      <li>Staff copying data between tools every morning</li>
-      <li>Weekly reports built by hand every Friday</li>
-      <li>Customers waiting because follow-up is a manual task</li>
-      <li>Managers chasing updates instead of getting them automatically</li>
-      <li>The same information entered in multiple places</li>
-      <li>Approvals sitting in email threads nobody checks</li>
+      <li>Staff copying data between tools every single morning</li>
+      <li>Weekly reports built by hand, every Friday, from scratch</li>
+      <li>Customers waiting because follow-up is still a manual task on someone's to-do list</li>
+      <li>Managers chasing status updates instead of getting AI-managed notifications automatically</li>
+      <li>The same information entered in multiple places by multiple people</li>
+      <li>Approvals sitting in email threads nobody checks — or remembers</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>What AI automation can handle for your team</h2>
-      <p>Not every task needs AI. But these ones do — and they're probably happening in your business right now.</p>
+      <h2>What AI-powered automation handles instead of your team</h2>
+      <p>Not every task needs AI — but these do. And they're probably happening in your business right now, eating hours your team will never get back.</p>
       <div class="grid">
-        <div class="card"><h3>Intake & Routing</h3><p>New requests arrive and get routed to the right person or queue automatically — no manual triage.</p></div>
-        <div class="card"><h3>Reminders & Follow-up</h3><p>Nothing falls through because a person forgot. Follow-up sequences run on schedule, every time.</p></div>
-        <div class="card"><h3>Reporting Summaries</h3><p>Weekly reports that used to take hours get generated automatically and delivered where your team needs them.</p></div>
-        <div class="card"><h3>Data Cleanup & Entry</h3><p>Messy incoming data gets structured and entered once — not re-entered three times across different tools.</p></div>
-        <div class="card"><h3>Handoff Tracking</h3><p>Work moves from step to step with a clear owner and visible status — no more "where is this at?" conversations.</p></div>
-        <div class="card"><h3>Document Processing</h3><p>Incoming documents get parsed, filed, and acted on — without someone reading and re-typing every one.</p></div>
+        <div class="card"><h3>AI-Managed Intake & Routing</h3><p>New requests arrive and get AI-routed to the right person or queue automatically — zero manual triage, zero dropped balls.</p></div>
+        <div class="card"><h3>AI-Powered Follow-up Sequences</h3><p>Nothing falls through because a person forgot. AI-managed follow-up sequences run on schedule, every time, without reminders.</p></div>
+        <div class="card"><h3>AI-Generated Reporting</h3><p>Weekly reports that used to take hours get AI-generated and delivered to your team — no Friday spreadsheet rescue missions.</p></div>
+        <div class="card"><h3>AI-Assisted Data Entry & Cleanup</h3><p>Messy incoming data gets AI-structured and entered once — not re-entered three times across disconnected tools.</p></div>
+        <div class="card"><h3>AI-Tracked Workflow Handoffs</h3><p>Work moves step to step with a clear owner and AI-updated status — no more "where is this at?" holding up your day.</p></div>
+        <div class="card"><h3>AI-Driven Document Processing</h3><p>Incoming documents get parsed, classified, and acted on by AI — without someone reading and re-typing every single one.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>What should stay human</h2>
-    <p>Good AI automation keeps people in the right places. We build systems that automate the repetitive and hand off the judgment calls.</p>
+    <h2>AI automates the repetitive. Humans handle what actually matters.</h2>
+    <p>Good AI-powered automation doesn't replace your team — it gives them back the hours they're currently losing to low-value work. Here's what stays human:</p>
     <ul class="check-list">
-      <li>Final approvals on sensitive decisions</li>
-      <li>Relationship-heavy customer communication</li>
-      <li>Anything requiring nuance, context, or accountability</li>
-      <li>Strategic calls your team is actually qualified to make</li>
+      <li>Final approvals on decisions that carry real consequences</li>
+      <li>Relationship-heavy customer conversations that need empathy, not efficiency</li>
+      <li>Anything requiring judgment, nuance, or accountability</li>
+      <li>The strategic calls your team is actually qualified — and paid — to make</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>How YourOS builds practical AI automation</h2>
-      <p>We don't drop an AI tool on your team and hope it sticks. We map first, then build around what's actually happening.</p>
+      <h2>How our AI-powered workflow audit works</h2>
+      <p>We don't drop an AI tool on your team and disappear. We map your real workflow first, then build AI automation around what's actually happening — not what someone assumed was happening.</p>
       <ul class="check-list">
-        <li>Map the workflow first — understand every manual step before writing a line of code</li>
-        <li>Automate the repeatable steps — the ones that happen the same way every time</li>
-        <li>Add AI only where it saves real time — not where it adds complexity</li>
-        <li>Keep humans in control — approvals, overrides, and visibility built in from day one</li>
-        <li>Built on AppSheet and Google Cloud — systems your team can actually use without an IT department</li>
+        <li>AI workflow audit first — we identify every manual step before writing a single line of automation</li>
+        <li>AI-automate the repeatable — the steps that happen the same way every time are the ones AI owns</li>
+        <li>Add AI intelligence only where it earns its place — not where it adds complexity for complexity's sake</li>
+        <li>Keep humans in the loop — AI-powered approval flows, overrides, and real-time visibility built in from day one</li>
+        <li>Built on AppSheet and Google Cloud — AI-enhanced systems your team can actually run without an IT department</li>
       </ul>
     </div>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>See What We'd Automate for You</h2>
-      <p>In one short session, we'll identify the manual steps, spreadsheet risks, and automation opportunities costing your team time every week.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+      <h2>Find Out What AI Would Eliminate From Your Workflow This Week</h2>
+      <p>In one focused session, we map the manual steps, surface the AI-automation opportunities, and show you exactly where your team is losing hours they don't have to lose.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Get Your Free AI Workflow Audit</a>
     </div>
     <div class="internal-links">
       <a href="/custom-workflow-automation/">Custom Workflow Automation →</a>

--- a/ai-automation-services-small-business/index.html
+++ b/ai-automation-services-small-business/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>AI Automation Services for Small Business | YourOS</title>
+  <meta name="description" content="We find the manual steps slowing your team down, then build practical AI automations and workflows around how your business already works. Book a free audit." />
+  <link rel="canonical" href="https://www.youros.app/ai-automation-services-small-business/" />
+  <meta name="robots" content="index, follow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg:#1c1c1e;--bg-alt:#2a2a2a;--primary:#0077ff;--primary-light:#00afff;
+      --action:#f97316;--action-hover:#ea580c;--text:#e6e8ec;--muted:#9ca3af;
+      --chrome:linear-gradient(135deg,#cfd4d9 0%,#9ea3a6 100%);--white:#fff;--black:#111;
+    }
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
+    a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}
+    a:hover{color:var(--primary-light);}
+    h1,h2,h3{font-weight:700;margin-bottom:1rem;}
+    h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}
+    h2{font-size:2rem;}h3{font-size:1.25rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}
+    .section{padding:4rem 0;}
+    p+p{margin-top:1rem;}
+    nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
+    .nav-left{display:flex;align-items:center;gap:0.75rem;}
+    .nav-left img{height:32px;width:auto;}
+    .nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
+    .nav-links{display:flex;align-items:center;gap:1.5rem;}
+    .nav-toggle{display:none;background:none;border:none;cursor:pointer;}
+    .nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
+    .nav-links a{text-decoration:none;color:var(--black);font-weight:500;}
+    .nav-links a:hover{color:var(--primary);}
+    .nav-cta-link{background:var(--action);color:var(--white)!important;padding:0.5rem 1.1rem;border-radius:6px;font-weight:600!important;font-size:0.9rem;transition:background .2s;}
+    .nav-cta-link:hover{background:var(--action-hover)!important;color:var(--white)!important;}
+    .dropdown{position:relative;}
+    .dropdown-content{display:none;position:absolute;top:100%;left:0;background:var(--white);min-width:220px;box-shadow:0 4px 8px rgba(0,0,0,.1);z-index:999;border-radius:4px;}
+    .dropdown-content a{display:block;padding:0.75rem 1rem;color:var(--black);font-size:0.9rem;}
+    .dropdown-content a:hover{background:#f2f2f2;color:var(--primary);}
+    .dropdown:hover .dropdown-content{display:block;}
+    .hero{background:radial-gradient(circle at center,rgba(249,115,22,.08) 0%,transparent 70%);padding:6rem 1.5rem 5rem;text-align:center;}
+    .hero-eyebrow{display:inline-block;background:rgba(249,115,22,.12);border:1px solid rgba(249,115,22,.3);color:var(--action);font-size:0.8rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;padding:0.35rem 1rem;border-radius:999px;margin-bottom:1.5rem;}
+    .hero h1{background:var(--chrome);-webkit-background-clip:text;color:transparent;max-width:820px;margin:0 auto 1.25rem;}
+    .hero p{font-size:1.15rem;max-width:640px;margin:0 auto;color:var(--muted);}
+    .cta{display:inline-block;background:var(--action);color:#fff;padding:1rem 2.25rem;border-radius:8px;box-shadow:0 0 12px rgba(249,115,22,.35);position:relative;overflow:hidden;transition:transform .2s,box-shadow .2s;font-weight:700;margin-top:2rem;}
+    .cta:hover{background:var(--action-hover);color:#fff;transform:translateY(-2px);box-shadow:0 0 20px rgba(249,115,22,.5);}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem;margin-top:2rem;}
+    .card{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:1.5rem;}
+    .card h3{font-size:1rem;margin-bottom:0.5rem;}
+    .card p{font-size:0.9rem;color:var(--muted);}
+    .check-list{list-style:none;margin-top:1.25rem;}
+    .check-list li{padding:0.5rem 0;border-bottom:1px solid rgba(255,255,255,.06);font-size:0.95rem;color:var(--text);display:flex;align-items:flex-start;gap:0.6rem;}
+    .check-list li::before{content:"✓";color:var(--action);font-weight:700;flex-shrink:0;}
+    .cta-block{background:rgba(249,115,22,.07);border:1px solid rgba(249,115,22,.2);border-radius:16px;padding:3.5rem 2rem;text-align:center;}
+    .cta-block h2{margin-bottom:0.75rem;}
+    .cta-block p{color:var(--muted);max-width:520px;margin:0 auto 2rem;}
+    footer{text-align:center;background:var(--bg-alt);padding:2rem 1.5rem;font-size:.9rem;color:var(--muted);}
+    .favicon-footer{position:fixed;bottom:20px;right:20px;width:32px;height:32px;opacity:0.8;}
+    .breadcrumb{font-size:0.85rem;color:var(--muted);padding:1rem 0;}
+    .breadcrumb a{color:var(--muted);font-weight:400;}
+    .breadcrumb a:hover{color:var(--text);}
+    .internal-links{display:flex;flex-wrap:wrap;gap:0.75rem;margin-top:2rem;}
+    .internal-links a{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:0.5rem 1rem;font-size:0.85rem;color:var(--text);font-weight:400;}
+    .internal-links a:hover{border-color:var(--action);color:var(--action);}
+    @media(max-width:768px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;}.nav-links.open{display:flex;}.nav-toggle{display:block;}}
+    @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+  </style>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
+</head>
+<body>
+  <nav>
+    <a class="nav-left" href="https://www.youros.app">
+      <img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Logo">
+      <span>YOUR Operating System</span>
+    </a>
+    <button class="nav-toggle" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+    <div class="nav-links">
+      <a href="https://www.youros.app/youros-home">YourOS Home</a>
+      <div class="dropdown">
+        <a href="#">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="/ai-automation-services-small-business/">AI Automation Services</a>
+          <a href="/custom-workflow-automation/">Custom Workflow Automation</a>
+          <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets</a>
+          <a href="/appsheet-consultant/">AppSheet Consulting</a>
+          <a href="/ai-assistants-for-business/">AI Assistants for Business</a>
+        </div>
+      </div>
+      <div class="dropdown">
+        <a href="https://www.youros.app/what-does-youros-do">What Does YourOS Do? ▾</a>
+        <div class="dropdown-content">
+          <a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a>
+        </div>
+      </div>
+      <a href="/blog/">Blog</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Workflow Audit</a>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <div class="hero-eyebrow">AI Automation Services</div>
+    <h1>AI Automation Services for Small Businesses That Are Tired of Repetitive Work</h1>
+    <p>We find the manual steps slowing your team down, then build practical AI automations and workflows around how your business already works.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+  </section>
+
+  <section class="section wrapper">
+    <div class="breadcrumb"><a href="/">Home</a> › AI Automation Services</div>
+    <h2>Signs your business is ready for AI automation</h2>
+    <p>If your team is doing any of these things regularly, you're losing hours every week to work a system could be doing instead.</p>
+    <ul class="check-list">
+      <li>Staff copying data between tools every morning</li>
+      <li>Weekly reports built by hand every Friday</li>
+      <li>Customers waiting because follow-up is a manual task</li>
+      <li>Managers chasing updates instead of getting them automatically</li>
+      <li>The same information entered in multiple places</li>
+      <li>Approvals sitting in email threads nobody checks</li>
+    </ul>
+  </section>
+
+  <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2>What AI automation can handle for your team</h2>
+      <p>Not every task needs AI. But these ones do — and they're probably happening in your business right now.</p>
+      <div class="grid">
+        <div class="card"><h3>Intake & Routing</h3><p>New requests arrive and get routed to the right person or queue automatically — no manual triage.</p></div>
+        <div class="card"><h3>Reminders & Follow-up</h3><p>Nothing falls through because a person forgot. Follow-up sequences run on schedule, every time.</p></div>
+        <div class="card"><h3>Reporting Summaries</h3><p>Weekly reports that used to take hours get generated automatically and delivered where your team needs them.</p></div>
+        <div class="card"><h3>Data Cleanup & Entry</h3><p>Messy incoming data gets structured and entered once — not re-entered three times across different tools.</p></div>
+        <div class="card"><h3>Handoff Tracking</h3><p>Work moves from step to step with a clear owner and visible status — no more "where is this at?" conversations.</p></div>
+        <div class="card"><h3>Document Processing</h3><p>Incoming documents get parsed, filed, and acted on — without someone reading and re-typing every one.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <h2>What should stay human</h2>
+    <p>Good AI automation keeps people in the right places. We build systems that automate the repetitive and hand off the judgment calls.</p>
+    <ul class="check-list">
+      <li>Final approvals on sensitive decisions</li>
+      <li>Relationship-heavy customer communication</li>
+      <li>Anything requiring nuance, context, or accountability</li>
+      <li>Strategic calls your team is actually qualified to make</li>
+    </ul>
+  </section>
+
+  <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2>How YourOS builds practical AI automation</h2>
+      <p>We don't drop an AI tool on your team and hope it sticks. We map first, then build around what's actually happening.</p>
+      <ul class="check-list">
+        <li>Map the workflow first — understand every manual step before writing a line of code</li>
+        <li>Automate the repeatable steps — the ones that happen the same way every time</li>
+        <li>Add AI only where it saves real time — not where it adds complexity</li>
+        <li>Keep humans in control — approvals, overrides, and visibility built in from day one</li>
+        <li>Built on AppSheet and Google Cloud — systems your team can actually use without an IT department</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <div class="cta-block">
+      <h2>See What We'd Automate for You</h2>
+      <p>In one short session, we'll identify the manual steps, spreadsheet risks, and automation opportunities costing your team time every week.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+    </div>
+    <div class="internal-links">
+      <a href="/custom-workflow-automation/">Custom Workflow Automation →</a>
+      <a href="/ai-assistants-for-business/">AI Assistants for Business →</a>
+      <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets →</a>
+      <a href="/appsheet-consultant/">AppSheet Consulting →</a>
+    </div>
+  </section>
+
+  <footer>© 2025 YourOS. Those who could excel, should excel.</footer>
+  <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
+  <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
+</body>
+</html>

--- a/appsheet-consultant/index.html
+++ b/appsheet-consultant/index.html
@@ -15,7 +15,7 @@
     body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
     a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
     h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
-    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding-top:4rem;padding-bottom:4rem;}p+p{margin-top:1rem;}
     nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
     .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
     .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
@@ -67,56 +67,56 @@
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">AppSheet Consultant</div>
-    <h1>AppSheet Consultant for Custom Business Apps Built Around Your Workflow</h1>
-    <p>We build practical AppSheet systems that replace spreadsheets, organize operations, and connect with the Google Workspace tools your team already uses — without enterprise complexity.</p>
+    <div class="hero-eyebrow">AI-Powered AppSheet Consulting</div>
+    <h1>Expert AppSheet Consultants Who Build AI-Enhanced Business Apps in Weeks, Not Months</h1>
+    <p>We build AI-powered AppSheet systems that replace your spreadsheets, automate your operations, and connect with the Google Workspace tools your team already uses — without the cost or complexity of enterprise software.</p>
     <a class="cta" href="/Begin-Your-Revolution.html">Talk to an AppSheet Consultant</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › AppSheet Consultant</div>
-    <h2>When AppSheet is the right fit</h2>
-    <p>AppSheet is Google's no-code app platform — and when it's set up correctly, it replaces the spreadsheets, email threads, and manual handoffs your team is currently surviving on.</p>
+    <h2>AppSheet with AI built in — when it's the right fit</h2>
+    <p>AppSheet is Google's no-code app platform. When it's built correctly — with AI automation layered in from the start — it replaces the spreadsheets, email threads, and manual handoffs your team is currently surviving on.</p>
     <ul class="check-list">
-      <li>Your team already uses Google Workspace (Sheets, Drive, Gmail, Calendar)</li>
-      <li>Your current process lives in spreadsheets that are getting too big or fragile</li>
-      <li>You have field teams who need mobile access to job data or forms</li>
-      <li>You need approval workflows without paying for enterprise software</li>
-      <li>You want a real app fast — without a 6-month development project</li>
+      <li>Your team already uses Google Workspace — Sheets, Drive, Gmail, Calendar are already the stack</li>
+      <li>Your current process lives in spreadsheets that are getting too big, too fragile, or too dependent on one person</li>
+      <li>You have field teams who need AI-assisted mobile access to job data, forms, and customer records</li>
+      <li>You need AI-managed approval workflows without paying enterprise software prices</li>
+      <li>You want a real AI-powered app fast — without a 6-month development project or an IT department</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>What we build with AppSheet</h2>
+      <h2>What we build with AppSheet — AI-powered from day one</h2>
       <div class="grid">
-        <div class="card"><h3>Custom Internal Apps</h3><p>Job trackers, intake systems, inspection tools — built around your actual workflow, not a generic template.</p></div>
-        <div class="card"><h3>Dashboards & Reports</h3><p>Live views of what matters to your team — no manual export, no spreadsheet rebuild on Friday.</p></div>
-        <div class="card"><h3>Forms & Structured Inputs</h3><p>Replace free-form emails and unstructured spreadsheet entries with validated, consistent data collection.</p></div>
-        <div class="card"><h3>Workflow Automations</h3><p>Notifications, assignments, status updates, and reminders that trigger automatically when things happen.</p></div>
-        <div class="card"><h3>Role-Based Views</h3><p>Managers see everything. Field staff see their jobs. Clients see their projects. Everyone sees what they need.</p></div>
-        <div class="card"><h3>AppSheet + AI Assistants</h3><p>Layer AI on top — summarize updates, draft responses, flag anomalies — while the AppSheet system stays the foundation.</p></div>
+        <div class="card"><h3>AI-Powered Custom Internal Apps</h3><p>Job trackers, AI-managed intake systems, inspection tools — built around your actual workflow, not someone else's template.</p></div>
+        <div class="card"><h3>AI-Generated Dashboards & Reports</h3><p>Live AI-powered views of what matters to your team — no manual export, no spreadsheet rebuild on Friday afternoon.</p></div>
+        <div class="card"><h3>AI-Validated Forms & Structured Inputs</h3><p>Replace free-form emails with AI-validated, structured data collection that's consistent every single time.</p></div>
+        <div class="card"><h3>AI-Triggered Workflow Automations</h3><p>AI-powered notifications, smart assignments, status updates, and reminders that fire automatically when things happen.</p></div>
+        <div class="card"><h3>AI-Personalized Role-Based Views</h3><p>Managers see everything. Field staff see their jobs. Clients see their projects. AI surfaces what each person needs.</p></div>
+        <div class="card"><h3>AppSheet + AI Assistant Integration</h3><p>AI layer on top — summarize updates, draft responses, flag anomalies — while the AppSheet system is the reliable foundation underneath.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>Why use a consultant instead of building it yourself</h2>
-    <p>AppSheet is no-code — but the decisions underneath it matter. A poorly structured data model creates the same problems as a bad spreadsheet, just harder to fix.</p>
+    <h2>Why an AI-experienced AppSheet consultant beats building it yourself</h2>
+    <p>AppSheet is no-code — but the decisions underneath it are everything. A poorly structured data model creates the same problems as a bad spreadsheet, just harder and more expensive to fix.</p>
     <ul class="check-list">
-      <li>Data structure determines everything — wrong tables mean the app won't scale</li>
-      <li>Workflow logic needs clean design — messy automations create more confusion than they solve</li>
-      <li>Permissions and security need planning from day one — not patched in later</li>
-      <li>The app has to match the real process — not an idealized version of it</li>
-      <li>We've built dozens of these — we know what breaks and what works</li>
+      <li>AI-ready data structure from day one — wrong tables mean the AI can't do its job and the app won't scale</li>
+      <li>Clean AI workflow logic — messy automations create more confusion than they solve, and AI amplifies both the good and the bad</li>
+      <li>AI-enforced permissions and security — planned from day one, not patched in after the first data incident</li>
+      <li>Mapped to your real AI-enhanced process — not an idealized version of it that nobody actually follows</li>
+      <li>We've built and deployed AI-powered AppSheet systems across multiple industries — we know what breaks and what scales</li>
     </ul>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Talk to an AppSheet Consultant</h2>
-      <p>Tell us what process you're trying to fix. We'll show you what a well-built AppSheet system looks like — and whether it's the right tool for your situation.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+      <h2>Talk to an AppSheet Consultant Who Builds AI In From the Start</h2>
+      <p>Tell us what process you're trying to fix. We'll show you what a well-built AI-powered AppSheet system looks like — and whether it's the right tool for your exact situation.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free AI Workflow Audit</a>
     </div>
     <div class="internal-links">
       <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets →</a>

--- a/appsheet-consultant/index.html
+++ b/appsheet-consultant/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>AppSheet Consultant – Custom Business Apps on Google AppSheet | YourOS</title>
+  <meta name="description" content="We build practical AppSheet systems that replace spreadsheets, organize operations, and connect with the Google Workspace tools your team already uses." />
+  <link rel="canonical" href="https://www.youros.app/appsheet-consultant/" />
+  <meta name="robots" content="index, follow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#1c1c1e;--bg-alt:#2a2a2a;--primary:#0077ff;--primary-light:#00afff;--action:#f97316;--action-hover:#ea580c;--text:#e6e8ec;--muted:#9ca3af;--chrome:linear-gradient(135deg,#cfd4d9 0%,#9ea3a6 100%);--white:#fff;--black:#111;}
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
+    a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
+    h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
+    .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
+    .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
+    .nav-links a{text-decoration:none;color:var(--black);font-weight:500;}.nav-links a:hover{color:var(--primary);}
+    .nav-cta-link{background:var(--action);color:var(--white)!important;padding:0.5rem 1.1rem;border-radius:6px;font-weight:600!important;font-size:0.9rem;transition:background .2s;}.nav-cta-link:hover{background:var(--action-hover)!important;color:var(--white)!important;}
+    .dropdown{position:relative;}.dropdown-content{display:none;position:absolute;top:100%;left:0;background:var(--white);min-width:220px;box-shadow:0 4px 8px rgba(0,0,0,.1);z-index:999;border-radius:4px;}
+    .dropdown-content a{display:block;padding:0.75rem 1rem;color:var(--black);font-size:0.9rem;}.dropdown-content a:hover{background:#f2f2f2;color:var(--primary);}.dropdown:hover .dropdown-content{display:block;}
+    .hero{background:radial-gradient(circle at center,rgba(249,115,22,.08) 0%,transparent 70%);padding:6rem 1.5rem 5rem;text-align:center;}
+    .hero-eyebrow{display:inline-block;background:rgba(249,115,22,.12);border:1px solid rgba(249,115,22,.3);color:var(--action);font-size:0.8rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;padding:0.35rem 1rem;border-radius:999px;margin-bottom:1.5rem;}
+    .hero h1{background:var(--chrome);-webkit-background-clip:text;color:transparent;max-width:820px;margin:0 auto 1.25rem;}
+    .hero p{font-size:1.15rem;max-width:640px;margin:0 auto;color:var(--muted);}
+    .cta{display:inline-block;background:var(--action);color:#fff;padding:1rem 2.25rem;border-radius:8px;box-shadow:0 0 12px rgba(249,115,22,.35);transition:transform .2s,box-shadow .2s;font-weight:700;margin-top:2rem;}
+    .cta:hover{background:var(--action-hover);color:#fff;transform:translateY(-2px);box-shadow:0 0 20px rgba(249,115,22,.5);}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem;margin-top:2rem;}
+    .card{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:1.5rem;}.card h3{font-size:1rem;margin-bottom:0.5rem;}.card p{font-size:0.9rem;color:var(--muted);}
+    .check-list{list-style:none;margin-top:1.25rem;}.check-list li{padding:0.5rem 0;border-bottom:1px solid rgba(255,255,255,.06);font-size:0.95rem;display:flex;align-items:flex-start;gap:0.6rem;}.check-list li::before{content:"✓";color:var(--action);font-weight:700;flex-shrink:0;}
+    .cta-block{background:rgba(249,115,22,.07);border:1px solid rgba(249,115,22,.2);border-radius:16px;padding:3.5rem 2rem;text-align:center;}.cta-block h2{margin-bottom:0.75rem;}.cta-block p{color:var(--muted);max-width:520px;margin:0 auto 2rem;}
+    .internal-links{display:flex;flex-wrap:wrap;gap:0.75rem;margin-top:2rem;}.internal-links a{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:0.5rem 1rem;font-size:0.85rem;color:var(--text);font-weight:400;}.internal-links a:hover{border-color:var(--action);color:var(--action);}
+    .breadcrumb{font-size:0.85rem;color:var(--muted);padding:1rem 0;}.breadcrumb a{color:var(--muted);font-weight:400;}.breadcrumb a:hover{color:var(--text);}
+    footer{text-align:center;background:var(--bg-alt);padding:2rem 1.5rem;font-size:.9rem;color:var(--muted);}
+    .favicon-footer{position:fixed;bottom:20px;right:20px;width:32px;height:32px;opacity:0.8;}
+    @media(max-width:768px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;}.nav-links.open{display:flex;}.nav-toggle{display:block;}}
+    @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+  </style>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
+</head>
+<body>
+  <nav>
+    <a class="nav-left" href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Logo"><span>YOUR Operating System</span></a>
+    <button class="nav-toggle" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+    <div class="nav-links">
+      <a href="https://www.youros.app/youros-home">YourOS Home</a>
+      <div class="dropdown"><a href="#">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="/ai-automation-services-small-business/">AI Automation Services</a>
+          <a href="/custom-workflow-automation/">Custom Workflow Automation</a>
+          <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets</a>
+          <a href="/appsheet-consultant/">AppSheet Consulting</a>
+          <a href="/ai-assistants-for-business/">AI Assistants for Business</a>
+        </div>
+      </div>
+      <div class="dropdown"><a href="https://www.youros.app/what-does-youros-do">What Does YourOS Do? ▾</a>
+        <div class="dropdown-content"><a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a></div>
+      </div>
+      <a href="/blog/">Blog</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Workflow Audit</a>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <div class="hero-eyebrow">AppSheet Consultant</div>
+    <h1>AppSheet Consultant for Custom Business Apps Built Around Your Workflow</h1>
+    <p>We build practical AppSheet systems that replace spreadsheets, organize operations, and connect with the Google Workspace tools your team already uses — without enterprise complexity.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Talk to an AppSheet Consultant</a>
+  </section>
+
+  <section class="section wrapper">
+    <div class="breadcrumb"><a href="/">Home</a> › AppSheet Consultant</div>
+    <h2>When AppSheet is the right fit</h2>
+    <p>AppSheet is Google's no-code app platform — and when it's set up correctly, it replaces the spreadsheets, email threads, and manual handoffs your team is currently surviving on.</p>
+    <ul class="check-list">
+      <li>Your team already uses Google Workspace (Sheets, Drive, Gmail, Calendar)</li>
+      <li>Your current process lives in spreadsheets that are getting too big or fragile</li>
+      <li>You have field teams who need mobile access to job data or forms</li>
+      <li>You need approval workflows without paying for enterprise software</li>
+      <li>You want a real app fast — without a 6-month development project</li>
+    </ul>
+  </section>
+
+  <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2>What we build with AppSheet</h2>
+      <div class="grid">
+        <div class="card"><h3>Custom Internal Apps</h3><p>Job trackers, intake systems, inspection tools — built around your actual workflow, not a generic template.</p></div>
+        <div class="card"><h3>Dashboards & Reports</h3><p>Live views of what matters to your team — no manual export, no spreadsheet rebuild on Friday.</p></div>
+        <div class="card"><h3>Forms & Structured Inputs</h3><p>Replace free-form emails and unstructured spreadsheet entries with validated, consistent data collection.</p></div>
+        <div class="card"><h3>Workflow Automations</h3><p>Notifications, assignments, status updates, and reminders that trigger automatically when things happen.</p></div>
+        <div class="card"><h3>Role-Based Views</h3><p>Managers see everything. Field staff see their jobs. Clients see their projects. Everyone sees what they need.</p></div>
+        <div class="card"><h3>AppSheet + AI Assistants</h3><p>Layer AI on top — summarize updates, draft responses, flag anomalies — while the AppSheet system stays the foundation.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <h2>Why use a consultant instead of building it yourself</h2>
+    <p>AppSheet is no-code — but the decisions underneath it matter. A poorly structured data model creates the same problems as a bad spreadsheet, just harder to fix.</p>
+    <ul class="check-list">
+      <li>Data structure determines everything — wrong tables mean the app won't scale</li>
+      <li>Workflow logic needs clean design — messy automations create more confusion than they solve</li>
+      <li>Permissions and security need planning from day one — not patched in later</li>
+      <li>The app has to match the real process — not an idealized version of it</li>
+      <li>We've built dozens of these — we know what breaks and what works</li>
+    </ul>
+  </section>
+
+  <section class="section wrapper">
+    <div class="cta-block">
+      <h2>Talk to an AppSheet Consultant</h2>
+      <p>Tell us what process you're trying to fix. We'll show you what a well-built AppSheet system looks like — and whether it's the right tool for your situation.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+    </div>
+    <div class="internal-links">
+      <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets →</a>
+      <a href="/custom-workflow-automation/">Custom Workflow Automation →</a>
+      <a href="/ai-assistants-for-business/">AI Assistants for Business →</a>
+    </div>
+  </section>
+
+  <footer>© 2025 YourOS. Those who could excel, should excel.</footer>
+  <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
+  <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
+</body>
+</html>

--- a/custom-workflow-automation/index.html
+++ b/custom-workflow-automation/index.html
@@ -15,7 +15,7 @@
     body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
     a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
     h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
-    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding-top:4rem;padding-bottom:4rem;}p+p{margin-top:1rem;}
     nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
     .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
     .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
@@ -67,57 +67,57 @@
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">Custom Workflow Automation</div>
-    <h1>Custom Workflow Automation for Teams Running on Duct-Taped Tools</h1>
-    <p>We turn scattered processes into clear, automated workflows your team can actually follow — no more chasing updates or asking "where is this at?"</p>
-    <a class="cta" href="/Begin-Your-Revolution.html">Show Us the Workflow That's Driving You Crazy</a>
+    <div class="hero-eyebrow">AI-Enhanced Workflow Automation</div>
+    <h1>Your Team's Chaos Has a Name. It's Called a Missing Workflow. We Fix That With AI.</h1>
+    <p>We replace scattered, duct-taped processes with AI-enhanced custom workflows your team can actually follow — automated handoffs, AI-managed notifications, and real-time status your team doesn't have to ask for.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Show Us the Workflow Breaking Your Team</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › Custom Workflow Automation</div>
-    <h2>Signs your workflow is costing you</h2>
-    <p>Most businesses don't realize how much the scattered process is actually costing them — until they see what a working system looks like.</p>
+    <h2>Signs your broken workflow is costing you more than you think</h2>
+    <p>Most businesses accept the chaos as normal — until they see an AI-powered workflow running alongside it. Then the cost of waiting becomes obvious.</p>
     <ul class="check-list">
-      <li>Work falls through the cracks between tools or people</li>
-      <li>Approvals live in email threads that never get read</li>
-      <li>Someone has to ask "where is this at?" every single day</li>
-      <li>Every report requires a spreadsheet rescue mission on Friday</li>
-      <li>New hires take months to learn the process because it lives in someone's head</li>
-      <li>The same data gets entered in two or three different places</li>
+      <li>Work falls through the cracks between tools, people, or inboxes every week</li>
+      <li>Approvals live in email threads that never get read — or get read too late</li>
+      <li>Someone has to physically ask "where is this at?" every single day</li>
+      <li>Every Friday report is a manual spreadsheet rescue mission</li>
+      <li>New hires take months to learn the process because it lives inside one person's head</li>
+      <li>The same data gets entered in two or three different places by two or three different people</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>What a custom workflow does instead</h2>
+      <h2>What an AI-powered custom workflow does instead</h2>
       <div class="grid">
-        <div class="card"><h3>Every step has an owner</h3><p>No ambiguity about who does what. The system assigns, notifies, and tracks — automatically.</p></div>
-        <div class="card"><h3>Work moves automatically</h3><p>When step one completes, step two starts. No manual handoff. No dropped ball.</p></div>
-        <div class="card"><h3>Data captured once</h3><p>Enter it in one place, see it everywhere. No re-entry, no version confusion, no "which spreadsheet is current?"</p></div>
-        <div class="card"><h3>Status is always visible</h3><p>Anyone can check where something stands without asking a person — because the system knows.</p></div>
-        <div class="card"><h3>Reminders before things go late</h3><p>The system flags approaching deadlines and overdue items automatically — without a manager chasing it.</p></div>
-        <div class="card"><h3>Reports without manual work</h3><p>Dashboards and summaries pull from live data, not from someone rebuilding a spreadsheet every week.</p></div>
+        <div class="card"><h3>AI-Assigned Ownership</h3><p>No ambiguity about who does what. The AI-powered system assigns, notifies, and tracks — so nobody can say they didn't know it was their job.</p></div>
+        <div class="card"><h3>AI-Driven Work Handoffs</h3><p>When step one completes, step two starts automatically. AI-triggered handoffs mean no dropped balls, no manual nudges.</p></div>
+        <div class="card"><h3>One Source of AI-Managed Truth</h3><p>Enter data once, see it everywhere. AI eliminates re-entry, version confusion, and the "which spreadsheet is current?" conversation.</p></div>
+        <div class="card"><h3>AI-Powered Status Visibility</h3><p>Anyone can check where something stands without asking a person — because the AI-powered system always knows and shows it.</p></div>
+        <div class="card"><h3>AI-Triggered Deadline Alerts</h3><p>AI flags approaching deadlines and overdue items before they become emergencies — without a manager chasing anyone.</p></div>
+        <div class="card"><h3>AI-Generated Reports</h3><p>Live dashboards and AI-generated summaries pull from real data — not from someone rebuilding a spreadsheet on their worst day of the week.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>Workflows we automate for small teams</h2>
+    <h2>AI-enhanced workflows we build for small teams</h2>
     <ul class="check-list">
-      <li>Customer onboarding — from first contact to fully set up, without manual handoffs</li>
-      <li>Service request handling — intake, assignment, status tracking, completion sign-off</li>
-      <li>Job and project tracking — where every job is, who owns it, what's next</li>
-      <li>Internal approvals — requests routed, approved, and logged without living in email</li>
-      <li>Weekly reporting — data collected and summarized automatically, delivered on schedule</li>
-      <li>Follow-up sequences — nothing falls through because someone forgot to send the email</li>
+      <li>AI-assisted customer onboarding — from first contact to fully set up, without a single manual handoff</li>
+      <li>AI-managed service request handling — intake, assignment, status tracking, and completion sign-off, automated</li>
+      <li>AI-powered job and project tracking — where every job is, who owns it, what's due, visible to everyone</li>
+      <li>AI-routed internal approvals — requests routed, approved, and logged without living in anyone's email</li>
+      <li>AI-generated weekly reporting — data collected and summarized automatically, delivered on schedule</li>
+      <li>AI-managed follow-up sequences — nothing falls through because AI doesn't forget to send the email</li>
     </ul>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Show Us the Workflow That's Driving You Crazy</h2>
-      <p>In one short session we'll map the broken process, identify the automation opportunities, and show you what a working system looks like.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+      <h2>Tell Us the Workflow That's Costing You the Most. We'll Fix It With AI.</h2>
+      <p>In one focused session, we map the broken process, surface the AI-automation opportunities, and show you exactly what a working system looks like — and how fast we can build it.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free AI Workflow Audit</a>
     </div>
     <div class="internal-links">
       <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets →</a>

--- a/custom-workflow-automation/index.html
+++ b/custom-workflow-automation/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Custom Workflow Automation for Small Business | YourOS</title>
+  <meta name="description" content="We turn scattered processes into clear, automated workflows your team can actually follow. Stop duct-taping tools together. Build a system that runs itself." />
+  <link rel="canonical" href="https://www.youros.app/custom-workflow-automation/" />
+  <meta name="robots" content="index, follow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#1c1c1e;--bg-alt:#2a2a2a;--primary:#0077ff;--primary-light:#00afff;--action:#f97316;--action-hover:#ea580c;--text:#e6e8ec;--muted:#9ca3af;--chrome:linear-gradient(135deg,#cfd4d9 0%,#9ea3a6 100%);--white:#fff;--black:#111;}
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
+    a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
+    h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
+    .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
+    .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
+    .nav-links a{text-decoration:none;color:var(--black);font-weight:500;}.nav-links a:hover{color:var(--primary);}
+    .nav-cta-link{background:var(--action);color:var(--white)!important;padding:0.5rem 1.1rem;border-radius:6px;font-weight:600!important;font-size:0.9rem;transition:background .2s;}.nav-cta-link:hover{background:var(--action-hover)!important;color:var(--white)!important;}
+    .dropdown{position:relative;}.dropdown-content{display:none;position:absolute;top:100%;left:0;background:var(--white);min-width:220px;box-shadow:0 4px 8px rgba(0,0,0,.1);z-index:999;border-radius:4px;}
+    .dropdown-content a{display:block;padding:0.75rem 1rem;color:var(--black);font-size:0.9rem;}.dropdown-content a:hover{background:#f2f2f2;color:var(--primary);}.dropdown:hover .dropdown-content{display:block;}
+    .hero{background:radial-gradient(circle at center,rgba(249,115,22,.08) 0%,transparent 70%);padding:6rem 1.5rem 5rem;text-align:center;}
+    .hero-eyebrow{display:inline-block;background:rgba(249,115,22,.12);border:1px solid rgba(249,115,22,.3);color:var(--action);font-size:0.8rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;padding:0.35rem 1rem;border-radius:999px;margin-bottom:1.5rem;}
+    .hero h1{background:var(--chrome);-webkit-background-clip:text;color:transparent;max-width:820px;margin:0 auto 1.25rem;}
+    .hero p{font-size:1.15rem;max-width:640px;margin:0 auto;color:var(--muted);}
+    .cta{display:inline-block;background:var(--action);color:#fff;padding:1rem 2.25rem;border-radius:8px;box-shadow:0 0 12px rgba(249,115,22,.35);position:relative;overflow:hidden;transition:transform .2s,box-shadow .2s;font-weight:700;margin-top:2rem;}
+    .cta:hover{background:var(--action-hover);color:#fff;transform:translateY(-2px);box-shadow:0 0 20px rgba(249,115,22,.5);}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem;margin-top:2rem;}
+    .card{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:1.5rem;}.card h3{font-size:1rem;margin-bottom:0.5rem;}.card p{font-size:0.9rem;color:var(--muted);}
+    .check-list{list-style:none;margin-top:1.25rem;}.check-list li{padding:0.5rem 0;border-bottom:1px solid rgba(255,255,255,.06);font-size:0.95rem;display:flex;align-items:flex-start;gap:0.6rem;}.check-list li::before{content:"✓";color:var(--action);font-weight:700;flex-shrink:0;}
+    .cta-block{background:rgba(249,115,22,.07);border:1px solid rgba(249,115,22,.2);border-radius:16px;padding:3.5rem 2rem;text-align:center;}.cta-block h2{margin-bottom:0.75rem;}.cta-block p{color:var(--muted);max-width:520px;margin:0 auto 2rem;}
+    .internal-links{display:flex;flex-wrap:wrap;gap:0.75rem;margin-top:2rem;}.internal-links a{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:0.5rem 1rem;font-size:0.85rem;color:var(--text);font-weight:400;}.internal-links a:hover{border-color:var(--action);color:var(--action);}
+    .breadcrumb{font-size:0.85rem;color:var(--muted);padding:1rem 0;}.breadcrumb a{color:var(--muted);font-weight:400;}.breadcrumb a:hover{color:var(--text);}
+    footer{text-align:center;background:var(--bg-alt);padding:2rem 1.5rem;font-size:.9rem;color:var(--muted);}
+    .favicon-footer{position:fixed;bottom:20px;right:20px;width:32px;height:32px;opacity:0.8;}
+    @media(max-width:768px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;}.nav-links.open{display:flex;}.nav-toggle{display:block;}}
+    @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+  </style>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
+</head>
+<body>
+  <nav>
+    <a class="nav-left" href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Logo"><span>YOUR Operating System</span></a>
+    <button class="nav-toggle" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+    <div class="nav-links">
+      <a href="https://www.youros.app/youros-home">YourOS Home</a>
+      <div class="dropdown"><a href="#">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="/ai-automation-services-small-business/">AI Automation Services</a>
+          <a href="/custom-workflow-automation/">Custom Workflow Automation</a>
+          <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets</a>
+          <a href="/appsheet-consultant/">AppSheet Consulting</a>
+          <a href="/ai-assistants-for-business/">AI Assistants for Business</a>
+        </div>
+      </div>
+      <div class="dropdown"><a href="https://www.youros.app/what-does-youros-do">What Does YourOS Do? ▾</a>
+        <div class="dropdown-content"><a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a></div>
+      </div>
+      <a href="/blog/">Blog</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Workflow Audit</a>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <div class="hero-eyebrow">Custom Workflow Automation</div>
+    <h1>Custom Workflow Automation for Teams Running on Duct-Taped Tools</h1>
+    <p>We turn scattered processes into clear, automated workflows your team can actually follow — no more chasing updates or asking "where is this at?"</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Show Us the Workflow That's Driving You Crazy</a>
+  </section>
+
+  <section class="section wrapper">
+    <div class="breadcrumb"><a href="/">Home</a> › Custom Workflow Automation</div>
+    <h2>Signs your workflow is costing you</h2>
+    <p>Most businesses don't realize how much the scattered process is actually costing them — until they see what a working system looks like.</p>
+    <ul class="check-list">
+      <li>Work falls through the cracks between tools or people</li>
+      <li>Approvals live in email threads that never get read</li>
+      <li>Someone has to ask "where is this at?" every single day</li>
+      <li>Every report requires a spreadsheet rescue mission on Friday</li>
+      <li>New hires take months to learn the process because it lives in someone's head</li>
+      <li>The same data gets entered in two or three different places</li>
+    </ul>
+  </section>
+
+  <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2>What a custom workflow does instead</h2>
+      <div class="grid">
+        <div class="card"><h3>Every step has an owner</h3><p>No ambiguity about who does what. The system assigns, notifies, and tracks — automatically.</p></div>
+        <div class="card"><h3>Work moves automatically</h3><p>When step one completes, step two starts. No manual handoff. No dropped ball.</p></div>
+        <div class="card"><h3>Data captured once</h3><p>Enter it in one place, see it everywhere. No re-entry, no version confusion, no "which spreadsheet is current?"</p></div>
+        <div class="card"><h3>Status is always visible</h3><p>Anyone can check where something stands without asking a person — because the system knows.</p></div>
+        <div class="card"><h3>Reminders before things go late</h3><p>The system flags approaching deadlines and overdue items automatically — without a manager chasing it.</p></div>
+        <div class="card"><h3>Reports without manual work</h3><p>Dashboards and summaries pull from live data, not from someone rebuilding a spreadsheet every week.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <h2>Workflows we automate for small teams</h2>
+    <ul class="check-list">
+      <li>Customer onboarding — from first contact to fully set up, without manual handoffs</li>
+      <li>Service request handling — intake, assignment, status tracking, completion sign-off</li>
+      <li>Job and project tracking — where every job is, who owns it, what's next</li>
+      <li>Internal approvals — requests routed, approved, and logged without living in email</li>
+      <li>Weekly reporting — data collected and summarized automatically, delivered on schedule</li>
+      <li>Follow-up sequences — nothing falls through because someone forgot to send the email</li>
+    </ul>
+  </section>
+
+  <section class="section wrapper">
+    <div class="cta-block">
+      <h2>Show Us the Workflow That's Driving You Crazy</h2>
+      <p>In one short session we'll map the broken process, identify the automation opportunities, and show you what a working system looks like.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+    </div>
+    <div class="internal-links">
+      <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets →</a>
+      <a href="/ai-automation-services-small-business/">AI Automation Services →</a>
+      <a href="/appsheet-consultant/">AppSheet Consulting →</a>
+    </div>
+  </section>
+
+  <footer>© 2025 YourOS. Those who could excel, should excel.</footer>
+  <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
+  <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     h3 { font-size: 1.25rem; }
 
     .wrapper { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
-    .section { padding: 4rem 0; }
+    .section { padding-top: 4rem; padding-bottom: 4rem; }
     p + p { margin-top: 1rem; }
 
     /* NAV */

--- a/index.html
+++ b/index.html
@@ -3,8 +3,9 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>YourOS – Built Around You</title>
-  <link rel="canonical" href="https://www.youros.app/youros-home" />
+  <title>YourOS – Custom AI Workflow Automation & AppSheet Systems for Small Business</title>
+  <meta name="description" content="We replace messy spreadsheets and manual workflows with custom systems that run your business. AI automation, AppSheet consulting, and workflow systems for small teams." />
+  <link rel="canonical" href="https://www.youros.app/" />
   <meta name="robots" content="index, follow" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" type="image/png" sizes="32x32"
@@ -17,6 +18,8 @@
       --bg-alt: #2a2a2a;
       --primary: #0077ff;
       --primary-light: #00afff;
+      --action: #f97316;
+      --action-hover: #ea580c;
       --text: #e6e8ec;
       --muted: #9ca3af;
       --chrome: linear-gradient(135deg, #cfd4d9 0%, #9ea3a6 100%);
@@ -24,11 +27,7 @@
       --black: #111;
     }
 
-    * {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
 
     body {
       font-family: 'Inter', system-ui, sans-serif;
@@ -38,379 +37,357 @@
       -webkit-font-smoothing: antialiased;
     }
 
-    a {
-      color: var(--primary);
-      font-weight: 600;
-      text-decoration: none;
-      transition: color .2s ease;
-    }
+    a { color: var(--primary); font-weight: 600; text-decoration: none; transition: color .2s ease; }
+    a:hover { color: var(--primary-light); }
 
-    a:hover {
-      color: var(--primary-light);
-    }
+    h1, h2, h3 { font-weight: 700; margin-bottom: 1rem; }
+    h1 { font-size: 2.75rem; letter-spacing: -0.02em; line-height: 1.15; }
+    h2 { font-size: 2rem; }
+    h3 { font-size: 1.25rem; }
 
-    h1,
-    h2,
-    h3 {
-      font-weight: 700;
-      margin-bottom: 1rem;
-    }
+    .wrapper { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
+    .section { padding: 4rem 0; }
+    p + p { margin-top: 1rem; }
 
-    h1 {
-      font-size: 2.75rem;
-      letter-spacing: -0.01em;
-    }
-
-    h2 {
-      font-size: 2rem;
-    }
-
-    h3 {
-      font-size: 1.25rem;
-    }
-
-    .wrapper {
-      max-width: 1100px;
-      margin: 0 auto;
-      padding: 0 1.5rem;
-    }
-
-    .section {
-      padding: 4rem 0;
-    }
-
-    p+p {
-      margin-top: 1rem;
-    }
-
-    /* === NAVBAR === */
+    /* NAV */
     nav {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      background: var(--white);
-      height: 64px;
-      padding: 0 2rem;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-      position: sticky;
-      top: 0;
-      z-index: 1000;
+      display: flex; align-items: center; justify-content: space-between;
+      background: var(--white); height: 64px; padding: 0 2rem;
+      box-shadow: 0 1px 4px rgba(0,0,0,.08); position: sticky; top: 0; z-index: 1000;
     }
-
-    .nav-left {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
+    .nav-left { display: flex; align-items: center; gap: 0.75rem; }
+    .nav-left img { height: 32px; width: auto; }
+    .nav-left span { font-weight: 600; font-size: 1rem; color: var(--black); }
+    .nav-links { display: flex; align-items: center; gap: 1.5rem; }
+    .nav-toggle { display: none; background: none; border: none; cursor: pointer; }
+    .nav-toggle span { display: block; width: 24px; height: 3px; margin: 5px 0; background: var(--black); }
+    .nav-links a { text-decoration: none; color: var(--black); font-weight: 500; }
+    .nav-links a:hover { color: var(--primary); }
+    .nav-cta-link {
+      background: var(--action); color: var(--white) !important; padding: 0.5rem 1.1rem;
+      border-radius: 6px; font-weight: 600 !important; font-size: 0.9rem;
+      transition: background .2s;
     }
-
-    .nav-left img {
-      height: 32px;
-      width: auto;
-    }
-
-    .nav-left span {
-      font-weight: 600;
-      font-size: 1rem;
-      color: var(--black);
-    }
-
-    .nav-links {
-      display: flex;
-      align-items: center;
-      gap: 1.5rem;
-    }
-
-    .nav-toggle {
-      display: none;
-      background: none;
-      border: none;
-      cursor: pointer;
-    }
-
-    .nav-toggle span {
-      display: block;
-      width: 24px;
-      height: 3px;
-      margin: 5px 0;
-      background: var(--black);
-    }
-
-    .nav-links a {
-      text-decoration: none;
-      color: var(--black);
-      font-weight: 500;
-      position: relative;
-    }
-
-    .nav-links a:hover {
-      color: var(--primary);
-    }
-
-    .dropdown {
-      position: relative;
-    }
-
+    .nav-cta-link:hover { background: var(--action-hover) !important; color: var(--white) !important; }
+    .dropdown { position: relative; }
     .dropdown-content {
-      display: none;
-      position: absolute;
-      top: 100%;
-      left: 0;
-      background: var(--white);
-      min-width: 200px;
-      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-      z-index: 999;
-      border-radius: 4px;
+      display: none; position: absolute; top: 100%; left: 0;
+      background: var(--white); min-width: 220px;
+      box-shadow: 0 4px 8px rgba(0,0,0,.1); z-index: 999; border-radius: 4px;
     }
-
-    .dropdown-content a {
-      display: block;
-      padding: 0.75rem 1rem;
-      color: var(--black);
-      text-decoration: none;
-      font-size: 0.95rem;
-    }
-
-    .dropdown-content a:hover {
-      background-color: #f2f2f2;
-      color: var(--primary);
-    }
-
-    .dropdown:hover .dropdown-content {
-      display: block;
-    }
-
+    .dropdown-content a { display: block; padding: 0.75rem 1rem; color: var(--black); font-size: 0.9rem; }
+    .dropdown-content a:hover { background: #f2f2f2; color: var(--primary); }
+    .dropdown:hover .dropdown-content { display: block; }
 
     /* HERO */
     .hero {
-      background: radial-gradient(circle at center, rgba(0, 119, 255, .15) 0%, transparent 70%);
-      text-align: center;
-      padding: 7rem 1.5rem 6rem;
+      background: radial-gradient(circle at center, rgba(0,119,255,.12) 0%, transparent 70%);
+      text-align: center; padding: 6rem 1.5rem 5rem;
     }
-
-    .hero h1 {
-      background: var(--chrome);
-      -webkit-background-clip: text;
-      color: transparent;
+    .hero-eyebrow {
+      display: inline-block; background: rgba(249,115,22,.12);
+      border: 1px solid rgba(249,115,22,.3); color: var(--action);
+      font-size: 0.8rem; font-weight: 700; letter-spacing: 1px;
+      text-transform: uppercase; padding: 0.35rem 1rem; border-radius: 999px; margin-bottom: 1.5rem;
     }
+    .hero h1 { background: var(--chrome); -webkit-background-clip: text; color: transparent; max-width: 820px; margin: 0 auto 0.5rem; }
+    .hero-tagline { font-size: 1.1rem; color: var(--action); font-weight: 600; margin-bottom: 1rem; }
+    .hero p { font-size: 1.15rem; max-width: 640px; margin: 0 auto; color: var(--muted); }
+    .hero-logo { display: block; margin: 1.5rem auto; max-width: 260px; width: 100%; height: auto; }
+    .cta-row { display: flex; gap: 1rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-top: 2rem; }
 
-    .hero p {
-      font-size: 1.2rem;
-      max-width: 680px;
-      margin: 1.5rem auto 0;
-      color: var(--muted);
-    }
-
+    /* CTA BUTTON */
     .cta {
-      display: inline-block;
-      background: var(--primary);
-      color: #fff;
-      padding: 1rem 2.25rem;
-      border-radius: 8px;
-      margin-top: 2rem;
-      box-shadow: inset 0 0 4px rgba(255, 255, 255, .15), 0 0 10px var(--primary-light);
-      position: relative;
-      overflow: hidden;
+      display: inline-block; background: var(--action); color: #fff;
+      padding: 1rem 2.25rem; border-radius: 8px;
+      box-shadow: 0 0 12px rgba(249,115,22,.35);
+      position: relative; overflow: hidden;
       transition: transform .2s ease, box-shadow .2s ease;
+      font-weight: 700;
     }
-
     .cta:hover {
-      transform: translateY(-2px);
-      box-shadow: inset 0 0 4px rgba(255, 255, 255, .2), 0 0 18px var(--primary-light);
+      background: var(--action-hover); color: #fff;
+      transform: translateY(-2px); box-shadow: 0 0 20px rgba(249,115,22,.5);
     }
-
     .cta::before {
-      content: "";
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.35), transparent);
-      transform: translateX(-100%);
-      animation: shimmer 2s infinite;
+      content: ""; position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+      background: linear-gradient(120deg, transparent, rgba(255,255,255,.25), transparent);
+      transform: translateX(-100%); animation: shimmer 2.5s infinite;
     }
-
     @keyframes shimmer {
-      0% {
-        transform: translateX(-100%);
-      }
-
-      50% {
-        transform: translateX(100%);
-      }
-
-      100% {
-        transform: translateX(100%);
-      }
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
     }
+    .cta-secondary {
+      display: inline-block; color: var(--muted); font-weight: 500; font-size: 0.95rem;
+      text-decoration: none; border-bottom: 1px solid rgba(156,163,175,.4);
+      transition: color .2s, border-color .2s;
+    }
+    .cta-secondary:hover { color: var(--text); border-color: var(--text); }
+
+    /* TRUST STRIP */
+    .trust-strip {
+      border-top: 1px solid rgba(255,255,255,.06); border-bottom: 1px solid rgba(255,255,255,.06);
+      background: rgba(255,255,255,.02); padding: 1rem 0;
+    }
+    .trust-strip-inner {
+      max-width: 1100px; margin: 0 auto; padding: 0 1.5rem;
+      display: flex; flex-wrap: wrap; gap: 0.25rem;
+    }
+    .trust-tag {
+      padding: 0.4rem 1.1rem; color: var(--muted); font-size: 0.85rem;
+      border-right: 1px solid rgba(255,255,255,.08);
+    }
+    .trust-tag:last-child { border-right: none; }
+
+    /* PAIN SECTION */
+    .pain-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; margin-top: 2rem;
+    }
+    .pain-item {
+      display: flex; align-items: flex-start; gap: 0.75rem;
+      background: rgba(255,255,255,.03); border: 1px solid rgba(255,255,255,.07);
+      border-radius: 10px; padding: 1rem 1.25rem;
+    }
+    .pain-dot { width: 8px; height: 8px; border-radius: 50%; background: #ef4444; flex-shrink: 0; margin-top: 0.45rem; }
+    .pain-item p { font-size: 0.95rem; color: var(--text); }
+
+    /* SERVICES GRID */
+    .services-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.25rem; margin-top: 2rem;
+    }
+    .service-card {
+      background: rgba(255,255,255,.03); border: 1px solid rgba(255,255,255,.08);
+      border-radius: 12px; padding: 1.75rem;
+      transition: border-color .2s;
+    }
+    .service-card:hover { border-color: var(--action); }
+    .service-card h3 { font-size: 1.1rem; margin-bottom: 0.5rem; }
+    .service-card p { font-size: 0.9rem; color: var(--muted); line-height: 1.6; }
+    .service-card a { font-size: 0.85rem; color: var(--action); display: inline-block; margin-top: 0.75rem; }
+    .service-card a:hover { color: var(--action-hover); }
+
+    /* STEPS */
+    .steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem; margin-top: 2rem; }
+    .step { text-align: center; }
+    .step-num {
+      width: 48px; height: 48px; border-radius: 50%; background: var(--action);
+      color: white; font-size: 1.25rem; font-weight: 800;
+      display: flex; align-items: center; justify-content: center; margin: 0 auto 1rem;
+    }
+    .step h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .step p { font-size: 0.9rem; color: var(--muted); }
+
+    /* CTA BLOCK */
+    .cta-block {
+      background: rgba(249,115,22,.07); border: 1px solid rgba(249,115,22,.2);
+      border-radius: 16px; padding: 3.5rem 2rem; text-align: center;
+    }
+    .cta-block h2 { margin-bottom: 0.75rem; }
+    .cta-block p { color: var(--muted); max-width: 520px; margin: 0 auto 2rem; }
 
     footer {
-      text-align: center;
-      background: var(--bg-alt);
-      padding: 2rem 1.5rem;
-      font-size: .9rem;
-      color: var(--muted);
+      text-align: center; background: var(--bg-alt);
+      padding: 2rem 1.5rem; font-size: .9rem; color: var(--muted);
     }
-
     .favicon-footer {
-      position: fixed;
-      bottom: 20px;
-      right: 20px;
-      width: 32px;
-      height: 32px;
-      opacity: 0.8;
-      pointer-events: auto;
+      position: fixed; bottom: 20px; right: 20px;
+      width: 32px; height: 32px; opacity: 0.8; pointer-events: auto;
     }
 
     @media(max-width: 768px) {
-      .nav-links,
-      .navbar-links {
-        display: none;
-        flex-direction: column;
-        position: absolute;
-        top: 64px;
-        right: 1rem;
-        background: var(--white);
-        padding: 1rem;
-        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-        border-radius: 4px;
+      .nav-links {
+        display: none; flex-direction: column; position: absolute;
+        top: 64px; right: 1rem; background: var(--white);
+        padding: 1rem; box-shadow: 0 4px 8px rgba(0,0,0,.1); border-radius: 4px;
       }
-
-      .nav-links.open,
-      .navbar-links.open {
-        display: flex;
-      }
-
-      .nav-toggle {
-        display: block;
-      }
+      .nav-links.open { display: flex; }
+      .nav-toggle { display: block; }
+      .cta-row { flex-direction: column; }
     }
-
-    @media(max-width: 1024px) {
-
-      .wrapper,
-      .hero {
-        padding-left: 1.5rem;
-        padding-right: 1.5rem;
-      }
-    }
-
     @media(max-width: 640px) {
-
-      .wrapper,
-      .hero {
-        padding-left: 1.25rem;
-        padding-right: 1.25rem;
-      }
-
-      h1 {
-        font-size: 2.25rem;
-      }
-
-      h2 {
-        font-size: 1.6rem;
-      }
+      h1 { font-size: 2.1rem; }
+      h2 { font-size: 1.6rem; }
     }
   </style>
-  <!-- Google tag (gtag.js) -->
+
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-
     gtag('config', 'G-Y74BBJGYND');
   </script>
 </head>
 
 <body>
 
-  <!-- ✅ NAVIGATION BAR -->
   <nav>
     <a class="nav-left" href="https://www.youros.app">
-      <img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="Logo">
+      <img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Logo">
       <span>YOUR Operating System</span>
     </a>
     <button class="nav-toggle" aria-label="Toggle navigation">
-      <span></span>
-      <span></span>
-      <span></span>
+      <span></span><span></span><span></span>
     </button>
     <div class="nav-links">
       <a href="https://www.youros.app/youros-home">YourOS Home</a>
       <div class="dropdown">
+        <a href="#">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="/ai-automation-services-small-business/">AI Automation Services</a>
+          <a href="/custom-workflow-automation/">Custom Workflow Automation</a>
+          <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets</a>
+          <a href="/appsheet-consultant/">AppSheet Consulting</a>
+          <a href="/ai-assistants-for-business/">AI Assistants for Business</a>
+        </div>
+      </div>
+      <div class="dropdown">
         <a href="https://www.youros.app/what-does-youros-do">What Does YourOS Do? ▾</a>
         <div class="dropdown-content">
-          <a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories and Testimony</a>
+          <a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a>
         </div>
       </div>
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
-      <a href="https://www.youros.app/pricing-competitors">Pricing & Competitors</a>
-      <a href="/blog/" style="color:var(--black)">Blog</a>
+      <a href="/blog/">Blog</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Workflow Audit</a>
     </div>
   </nav>
 
   <!-- HERO -->
   <section class="hero">
-    <h1>You’re not broken. Your software is.</h1>
-    <img src="https://i.postimg.cc/Bnrbwc51/Your-OS-Logo.png" alt="YourOS Logo"
-      style="display:block;margin:1rem auto;max-width:300px;width:100%;height:auto;">
-    <p>YourOS isn't just different—it’s the first system that finally listens to YOU. No templates. No lag. Just your
-      way, operationalized.</p>
-    <a class="cta" href="Begin-Your-Revolution.html" target="_blank" rel="noopener">Meet the OS That
-      Works With You</a>
+    <div class="hero-eyebrow">Custom AI Systems for Small Business</div>
+    <h1>We Replace Messy Spreadsheets and Manual Workflows With Custom Systems That Run Your Business</h1>
+    <p class="hero-tagline">You're not broken. Your software is.</p>
+    <img class="hero-logo" src="https://i.postimg.cc/Bnrbwc51/Your-OS-Logo.png" alt="YourOS Logo">
+    <p>For small teams tired of duct-taped tools, version confusion, repetitive reporting, and the one person who has to keep the whole process in their head.</p>
+    <div class="cta-row">
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+      <a class="cta-secondary" href="#services">See what we build →</a>
+    </div>
   </section>
 
-  <!-- ENEMY SECTION -->
+  <!-- TRUST STRIP -->
+  <div class="trust-strip">
+    <div class="trust-strip-inner">
+      <span class="trust-tag">AI workflow automation</span>
+      <span class="trust-tag">AppSheet consulting</span>
+      <span class="trust-tag">custom internal apps</span>
+      <span class="trust-tag">replace spreadsheets</span>
+      <span class="trust-tag">AI assistants for business</span>
+      <span class="trust-tag">Utah-based</span>
+    </div>
+  </div>
+
+  <!-- PAIN SECTION -->
   <section class="section wrapper" id="enemy">
     <h2>You may be suffering from <em>Process Thrombosis</em>.</h2>
-    <p>Symptoms include: inbox swelling, spreadsheet scatter, workflow paralysis, and an allergic reaction to your own
-      software stack.</p>
-    <p><strong>Left untreated, it leads to chronic meetings, dashboard vertigo, and eventual burnout.</strong></p>
-    <p>The diagnosis? BrokenOS.</p>
+    <p>Symptoms include: inbox swelling, spreadsheet scatter, workflow paralysis, and an allergic reaction to your own software stack.</p>
+    <p style="margin-top:0.75rem;color:var(--muted);">Sound familiar? Your business is running on hidden manual work — and it's costing you more than you think.</p>
+    <div class="pain-grid">
+      <div class="pain-item"><div class="pain-dot"></div><p>Copying data between tools every morning</p></div>
+      <div class="pain-item"><div class="pain-dot"></div><p>Weekly reports that take hours to build by hand</p></div>
+      <div class="pain-item"><div class="pain-dot"></div><p>Approvals stuck in email threads nobody checks</p></div>
+      <div class="pain-item"><div class="pain-dot"></div><p>One person who understands how the whole system works</p></div>
+      <div class="pain-item"><div class="pain-dot"></div><p>Version confusion on shared spreadsheets</p></div>
+      <div class="pain-item"><div class="pain-dot"></div><p>Work falling through the cracks between tools</p></div>
+    </div>
   </section>
 
-  <!-- DIFFERENTIATOR -->
-  <section class="section wrapper" id="process">
-    <h2>We’re not another tool. We’re YourOS.</h2>
-    <p><strong>YourOS is built around you.</strong> We listen, we adapt, and we deploy fast.</p>
-    <p>Forget bloatware. Forget onboarding to someone else's vision. With YourOS, the system wraps around your
-      workflow—not the other way around.</p>
-    <p style="margin-top:1rem; font-size:1.25rem;"><em>Your mess. Our mission.</em></p>
+  <!-- SERVICES -->
+  <section class="section wrapper" id="services">
+    <h2>We're not another tool. We're YourOS.</h2>
+    <p><strong>YourOS is built around you.</strong> We listen, we map your workflow, and we build a custom operating system that runs your business — not someone else's template.</p>
+    <div class="services-grid" style="margin-top:2.5rem;">
+      <div class="service-card">
+        <h3>⚡ AI Workflow Automation</h3>
+        <p>We find the manual steps that repeat every day and build automations that run them for you — intake, routing, follow-up, reminders, handoffs.</p>
+        <a href="/ai-automation-services-small-business/">Learn more →</a>
+      </div>
+      <div class="service-card">
+        <h3>🔧 Custom Workflow Systems</h3>
+        <p>Turn scattered processes into clean, automated workflows. Every step has an owner. Status is visible. Work stops falling through cracks.</p>
+        <a href="/custom-workflow-automation/">Learn more →</a>
+      </div>
+      <div class="service-card">
+        <h3>📊 Replace Spreadsheets</h3>
+        <p>We turn fragile spreadsheets into custom apps that track work, enforce process, reduce errors, and give your team one source of truth.</p>
+        <a href="/replace-spreadsheets-with-custom-app/">Learn more →</a>
+      </div>
+      <div class="service-card">
+        <h3>📱 AppSheet Consulting</h3>
+        <p>Custom internal apps, dashboards, approval flows, and field-team tools built on Google AppSheet and connected to your Workspace.</p>
+        <a href="/appsheet-consultant/">Learn more →</a>
+      </div>
+      <div class="service-card">
+        <h3>🤖 AI Assistants for Business</h3>
+        <p>AI sidekicks that summarize, draft, route, search, and act inside the systems your business already uses. Practical, not theatrical.</p>
+        <a href="/ai-assistants-for-business/">Learn more →</a>
+      </div>
+      <div class="service-card">
+        <h3>📍 Utah AI Consulting</h3>
+        <p>Local to Utah. We work with businesses across Salt Lake City, Tooele County, and the Wasatch Front to build practical AI operating systems.</p>
+        <a href="/utah-ai-automation/">Learn more →</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- HOW IT WORKS -->
+  <section class="section" style="background:var(--bg-alt); border-top:1px solid rgba(255,255,255,.06); border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2 style="text-align:center;">From Broken Process to Running System</h2>
+      <p style="text-align:center;color:var(--muted);max-width:520px;margin:0.5rem auto 0;">Four steps. No enterprise bloat. No six-month timelines. <em>Your mess. Our mission.</em></p>
+      <div class="steps">
+        <div class="step">
+          <div class="step-num">1</div>
+          <h3>Workflow Audit</h3>
+          <p>We map your manual steps, spreadsheet risks, and automation opportunities in one short session.</p>
+        </div>
+        <div class="step">
+          <div class="step-num">2</div>
+          <h3>Build</h3>
+          <p>We design and build a custom system around your workflow — not a generic template.</p>
+        </div>
+        <div class="step">
+          <div class="step-num">3</div>
+          <h3>Launch</h3>
+          <p>We deploy fast, train your team, and make sure the process actually runs the way it should.</p>
+        </div>
+        <div class="step">
+          <div class="step-num">4</div>
+          <h3>Iterate</h3>
+          <p>We improve, automate more, and keep the system aligned as your business grows.</p>
+        </div>
+      </div>
+    </div>
   </section>
 
   <!-- PHILOSOPHY -->
   <section class="section wrapper">
-    <p style="color:var(--muted);">They build software to make you change.</p>
-    <p><strong>We build systems that change with <em>you</em>.</strong></p>
+    <p style="color:var(--muted); font-size:1.1rem;">They build software to make you change.</p>
+    <p style="font-size:1.25rem;"><strong>We build systems that change with <em>you</em>.</strong></p>
+    <p style="margin-top:1rem;color:var(--muted);">We work with a limited number of clients each month. When you book, you're not a number — you're our focus.</p>
   </section>
 
-  <!-- CTA BOOKING -->
-  <section class="section wrapper" style="text-align:center">
-    <h3>We work with a limited number of clients each month.</h3>
-    <p>That means when you book, you're not a number. You're our focus.</p>
-    <a class="cta" href="Begin-Your-Revolution.html" target="_blank" rel="noopener">Book Your
-      Discovery Call</a>
-    <p style="margin-top:0.5rem;font-size:0.9rem;color:var(--muted);">20 minutes to ditch BrokenOS—and become the ops
-      hero of your team.</p>
+  <!-- CTA BLOCK -->
+  <section class="section wrapper">
+    <div class="cta-block">
+      <h2>Show Us the Workflow That's Driving You Crazy</h2>
+      <p>In one short session, we'll identify the manual steps, spreadsheet risks, and automation opportunities that are costing your team time every week.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html" style="font-size:1.1rem; padding:1.1rem 2.5rem;">Book a Free Workflow Audit</a>
+      <p style="margin-top:0.75rem;font-size:0.85rem;color:var(--muted);">20 minutes to ditch BrokenOS — and become the ops hero of your team.</p>
+    </div>
   </section>
 
-  <!-- FOOTER -->
-  <footer>© 2025 YourOS. Those who could excel, should excel</footer>
-  <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon"
-    class="favicon-footer"></a>
+  <footer>© 2025 YourOS. Those who could excel, should excel.</footer>
+  <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
 
   <script>
     const toggle = document.querySelector('.nav-toggle');
-    const links = document.querySelector('.nav-links') || document.querySelector('.navbar-links');
-    if (toggle && links) {
-      toggle.addEventListener('click', () => {
-        links.classList.toggle('open');
-      });
-    }
+    const links = document.querySelector('.nav-links');
+    if (toggle && links) toggle.addEventListener('click', () => links.classList.toggle('open'));
   </script>
-
 </body>
-
 </html>

--- a/replace-spreadsheets-with-custom-app/index.html
+++ b/replace-spreadsheets-with-custom-app/index.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Replace Spreadsheets With a Custom App | YourOS</title>
+  <meta name="description" content="We turn fragile spreadsheets into custom apps that track work, reduce mistakes, and give your team one place to run the process. Built on AppSheet and Google Cloud." />
+  <link rel="canonical" href="https://www.youros.app/replace-spreadsheets-with-custom-app/" />
+  <meta name="robots" content="index, follow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#1c1c1e;--bg-alt:#2a2a2a;--primary:#0077ff;--primary-light:#00afff;--action:#f97316;--action-hover:#ea580c;--text:#e6e8ec;--muted:#9ca3af;--chrome:linear-gradient(135deg,#cfd4d9 0%,#9ea3a6 100%);--white:#fff;--black:#111;}
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
+    a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
+    h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
+    .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
+    .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
+    .nav-links a{text-decoration:none;color:var(--black);font-weight:500;}.nav-links a:hover{color:var(--primary);}
+    .nav-cta-link{background:var(--action);color:var(--white)!important;padding:0.5rem 1.1rem;border-radius:6px;font-weight:600!important;font-size:0.9rem;transition:background .2s;}.nav-cta-link:hover{background:var(--action-hover)!important;color:var(--white)!important;}
+    .dropdown{position:relative;}.dropdown-content{display:none;position:absolute;top:100%;left:0;background:var(--white);min-width:220px;box-shadow:0 4px 8px rgba(0,0,0,.1);z-index:999;border-radius:4px;}
+    .dropdown-content a{display:block;padding:0.75rem 1rem;color:var(--black);font-size:0.9rem;}.dropdown-content a:hover{background:#f2f2f2;color:var(--primary);}.dropdown:hover .dropdown-content{display:block;}
+    .hero{background:radial-gradient(circle at center,rgba(249,115,22,.08) 0%,transparent 70%);padding:6rem 1.5rem 5rem;text-align:center;}
+    .hero-eyebrow{display:inline-block;background:rgba(249,115,22,.12);border:1px solid rgba(249,115,22,.3);color:var(--action);font-size:0.8rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;padding:0.35rem 1rem;border-radius:999px;margin-bottom:1.5rem;}
+    .hero h1{background:var(--chrome);-webkit-background-clip:text;color:transparent;max-width:820px;margin:0 auto 1.25rem;}
+    .hero p{font-size:1.15rem;max-width:640px;margin:0 auto;color:var(--muted);}
+    .cta{display:inline-block;background:var(--action);color:#fff;padding:1rem 2.25rem;border-radius:8px;box-shadow:0 0 12px rgba(249,115,22,.35);transition:transform .2s,box-shadow .2s;font-weight:700;margin-top:2rem;}
+    .cta:hover{background:var(--action-hover);color:#fff;transform:translateY(-2px);box-shadow:0 0 20px rgba(249,115,22,.5);}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem;margin-top:2rem;}
+    .card{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:1.5rem;}.card h3{font-size:1rem;margin-bottom:0.5rem;}.card p{font-size:0.9rem;color:var(--muted);}
+    .check-list{list-style:none;margin-top:1.25rem;}.check-list li{padding:0.5rem 0;border-bottom:1px solid rgba(255,255,255,.06);font-size:0.95rem;display:flex;align-items:flex-start;gap:0.6rem;}.check-list li::before{content:"✓";color:var(--action);font-weight:700;flex-shrink:0;}
+    .compare-table{width:100%;border-collapse:collapse;margin-top:2rem;font-size:0.9rem;}
+    .compare-table th{padding:0.75rem 1rem;text-align:left;border-bottom:2px solid rgba(255,255,255,.1);color:var(--muted);font-weight:600;}
+    .compare-table td{padding:0.75rem 1rem;border-bottom:1px solid rgba(255,255,255,.06);}
+    .compare-table tr td:first-child{color:var(--muted);}
+    .compare-table .bad{color:#f87171;}.compare-table .good{color:#4ade80;}
+    .cta-block{background:rgba(249,115,22,.07);border:1px solid rgba(249,115,22,.2);border-radius:16px;padding:3.5rem 2rem;text-align:center;}.cta-block h2{margin-bottom:0.75rem;}.cta-block p{color:var(--muted);max-width:520px;margin:0 auto 2rem;}
+    .internal-links{display:flex;flex-wrap:wrap;gap:0.75rem;margin-top:2rem;}.internal-links a{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:0.5rem 1rem;font-size:0.85rem;color:var(--text);font-weight:400;}.internal-links a:hover{border-color:var(--action);color:var(--action);}
+    .breadcrumb{font-size:0.85rem;color:var(--muted);padding:1rem 0;}.breadcrumb a{color:var(--muted);font-weight:400;}.breadcrumb a:hover{color:var(--text);}
+    footer{text-align:center;background:var(--bg-alt);padding:2rem 1.5rem;font-size:.9rem;color:var(--muted);}
+    .favicon-footer{position:fixed;bottom:20px;right:20px;width:32px;height:32px;opacity:0.8;}
+    @media(max-width:768px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;}.nav-links.open{display:flex;}.nav-toggle{display:block;}}
+    @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}.compare-table{font-size:0.8rem;}}
+  </style>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
+</head>
+<body>
+  <nav>
+    <a class="nav-left" href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Logo"><span>YOUR Operating System</span></a>
+    <button class="nav-toggle" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+    <div class="nav-links">
+      <a href="https://www.youros.app/youros-home">YourOS Home</a>
+      <div class="dropdown"><a href="#">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="/ai-automation-services-small-business/">AI Automation Services</a>
+          <a href="/custom-workflow-automation/">Custom Workflow Automation</a>
+          <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets</a>
+          <a href="/appsheet-consultant/">AppSheet Consulting</a>
+          <a href="/ai-assistants-for-business/">AI Assistants for Business</a>
+        </div>
+      </div>
+      <div class="dropdown"><a href="https://www.youros.app/what-does-youros-do">What Does YourOS Do? ▾</a>
+        <div class="dropdown-content"><a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a></div>
+      </div>
+      <a href="/blog/">Blog</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Workflow Audit</a>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <div class="hero-eyebrow">Replace Spreadsheets</div>
+    <h1>Replace Spreadsheets With a Custom App That Runs Your Business</h1>
+    <p>We turn fragile spreadsheets into custom apps that track work, reduce mistakes, and give your team one source of truth — built around how you actually operate.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+  </section>
+
+  <section class="section wrapper">
+    <div class="breadcrumb"><a href="/">Home</a> › Replace Spreadsheets With a Custom App</div>
+    <h2>Signs your spreadsheets are breaking your business</h2>
+    <p>Spreadsheets are flexible — until they become the unofficial operating system. Then they become a liability.</p>
+    <ul class="check-list">
+      <li>Version confusion — nobody knows which file is current</li>
+      <li>Formulas nobody wants to touch because something might break</li>
+      <li>Manual reporting every week from data scattered across tabs</li>
+      <li>People emailing copies of the same file back and forth</li>
+      <li>One person who understands the system — and what happens when they're out?</li>
+      <li>No real permissions, process control, or audit trail</li>
+    </ul>
+  </section>
+
+  <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
+    <div class="wrapper">
+      <h2>Spreadsheet vs. custom app — the real difference</h2>
+      <table class="compare-table">
+        <thead><tr><th>The problem</th><th>Spreadsheet</th><th>YourOS custom app</th></tr></thead>
+        <tbody>
+          <tr><td>Data entry</td><td class="bad">Multiple people, multiple files, no validation</td><td class="good">One place, structured inputs, no duplicates</td></tr>
+          <tr><td>Version control</td><td class="bad">Emailed copies, conflicting edits</td><td class="good">Single source of truth, always current</td></tr>
+          <tr><td>Reporting</td><td class="bad">Manual rebuild every week</td><td class="good">Live dashboards, automated summaries</td></tr>
+          <tr><td>Approvals</td><td class="bad">Email threads, no tracking</td><td class="good">Built-in workflow, logged decisions</td></tr>
+          <tr><td>Permissions</td><td class="bad">Anyone can edit anything</td><td class="good">Role-based access, controlled views</td></tr>
+          <tr><td>Process knowledge</td><td class="bad">Lives in one person's head</td><td class="good">Encoded in the system</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <h2>What we build to replace spreadsheets</h2>
+    <div class="grid">
+      <div class="card"><h3>Job & Project Trackers</h3><p>Every job has a status, owner, and history. No spreadsheet required to know where things stand.</p></div>
+      <div class="card"><h3>Intake & Routing Systems</h3><p>New requests come in structured, get assigned automatically, and move through the process without manual triage.</p></div>
+      <div class="card"><h3>Approval Workflows</h3><p>Requests route to the right approver, decisions get logged, and nothing waits in a forgotten inbox.</p></div>
+      <div class="card"><h3>Field Team Apps</h3><p>Mobile-friendly apps for teams in the field — inspections, time tracking, job updates, photo capture.</p></div>
+      <div class="card"><h3>Reporting Dashboards</h3><p>Live views of the data that matters — no manual export, no Friday afternoon spreadsheet rebuild.</p></div>
+      <div class="card"><h3>Client & Project Portals</h3><p>Clients or internal teams see exactly what they need — filtered to their role and updated in real time.</p></div>
+    </div>
+  </section>
+
+  <section class="section wrapper">
+    <div class="cta-block">
+      <h2>Replace the Spreadsheet That Runs Your Business</h2>
+      <p>Tell us which spreadsheet is the most fragile part of your operation. We'll show you what a working system looks like in its place.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+    </div>
+    <div class="internal-links">
+      <a href="/appsheet-consultant/">AppSheet Consulting →</a>
+      <a href="/custom-workflow-automation/">Custom Workflow Automation →</a>
+      <a href="/ai-automation-services-small-business/">AI Automation Services →</a>
+    </div>
+  </section>
+
+  <footer>© 2025 YourOS. Those who could excel, should excel.</footer>
+  <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
+  <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
+</body>
+</html>

--- a/replace-spreadsheets-with-custom-app/index.html
+++ b/replace-spreadsheets-with-custom-app/index.html
@@ -15,7 +15,7 @@
     body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;}
     a{color:var(--primary);font-weight:600;text-decoration:none;transition:color .2s;}a:hover{color:var(--primary-light);}
     h1,h2,h3{font-weight:700;margin-bottom:1rem;}h1{font-size:2.75rem;letter-spacing:-0.02em;line-height:1.15;}h2{font-size:2rem;}h3{font-size:1.25rem;}
-    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding:4rem 0;}p+p{margin-top:1rem;}
+    .wrapper{max-width:1100px;margin:0 auto;padding:0 1.5rem;}.section{padding-top:4rem;padding-bottom:4rem;}p+p{margin-top:1rem;}
     nav{display:flex;align-items:center;justify-content:space-between;background:var(--white);height:64px;padding:0 2rem;box-shadow:0 1px 4px rgba(0,0,0,.08);position:sticky;top:0;z-index:1000;}
     .nav-left{display:flex;align-items:center;gap:0.75rem;}.nav-left img{height:32px;width:auto;}.nav-left span{font-weight:600;font-size:1rem;color:var(--black);}
     .nav-links{display:flex;align-items:center;gap:1.5rem;}.nav-toggle{display:none;background:none;border:none;cursor:pointer;}.nav-toggle span{display:block;width:24px;height:3px;margin:5px 0;background:var(--black);}
@@ -72,60 +72,60 @@
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">Replace Spreadsheets</div>
-    <h1>Replace Spreadsheets With a Custom App That Runs Your Business</h1>
-    <p>We turn fragile spreadsheets into custom apps that track work, reduce mistakes, and give your team one source of truth — built around how you actually operate.</p>
-    <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+    <div class="hero-eyebrow">Replace Spreadsheets With AI-Powered Apps</div>
+    <h1>Your Spreadsheet Is One Bad Formula Away From a Crisis. Build Something That Won't Break.</h1>
+    <p>We replace fragile spreadsheets with AI-powered custom apps that track work, enforce the right process, and give your team one real source of truth — built around how you actually operate, not how software thinks you should.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Show Us Your Most Dangerous Spreadsheet</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › Replace Spreadsheets With a Custom App</div>
-    <h2>Signs your spreadsheets are breaking your business</h2>
-    <p>Spreadsheets are flexible — until they become the unofficial operating system. Then they become a liability.</p>
+    <h2>Signs your spreadsheet has become a liability, not a tool</h2>
+    <p>Spreadsheets are flexible — until they become the unofficial operating system of your business. Then they become a single point of failure nobody wants to admit is there.</p>
     <ul class="check-list">
-      <li>Version confusion — nobody knows which file is current</li>
-      <li>Formulas nobody wants to touch because something might break</li>
-      <li>Manual reporting every week from data scattered across tabs</li>
-      <li>People emailing copies of the same file back and forth</li>
-      <li>One person who understands the system — and what happens when they're out?</li>
-      <li>No real permissions, process control, or audit trail</li>
+      <li>Version confusion — three people, three files, nobody knows which one is real</li>
+      <li>Formulas nobody dares touch because something might break in ways nobody understands</li>
+      <li>Manual reporting every week from data scattered across 12 tabs nobody labeled properly</li>
+      <li>People emailing copies of the same file back and forth, editing their own version in isolation</li>
+      <li>One person who understands the whole system — and zero plan for when they leave or are out sick</li>
+      <li>No real permissions, no process control, no audit trail — just trust and fingers crossed</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>Spreadsheet vs. custom app — the real difference</h2>
+      <h2>Spreadsheet vs. AI-powered custom app — what actually changes</h2>
       <table class="compare-table">
-        <thead><tr><th>The problem</th><th>Spreadsheet</th><th>YourOS custom app</th></tr></thead>
+        <thead><tr><th>The problem</th><th>Spreadsheet</th><th>YourOS AI-powered app</th></tr></thead>
         <tbody>
-          <tr><td>Data entry</td><td class="bad">Multiple people, multiple files, no validation</td><td class="good">One place, structured inputs, no duplicates</td></tr>
-          <tr><td>Version control</td><td class="bad">Emailed copies, conflicting edits</td><td class="good">Single source of truth, always current</td></tr>
-          <tr><td>Reporting</td><td class="bad">Manual rebuild every week</td><td class="good">Live dashboards, automated summaries</td></tr>
-          <tr><td>Approvals</td><td class="bad">Email threads, no tracking</td><td class="good">Built-in workflow, logged decisions</td></tr>
-          <tr><td>Permissions</td><td class="bad">Anyone can edit anything</td><td class="good">Role-based access, controlled views</td></tr>
-          <tr><td>Process knowledge</td><td class="bad">Lives in one person's head</td><td class="good">Encoded in the system</td></tr>
+          <tr><td>Data entry</td><td class="bad">Multiple people, multiple files, zero validation</td><td class="good">One place, AI-validated structured inputs, no duplicates</td></tr>
+          <tr><td>Version control</td><td class="bad">Emailed copies, conflicting edits, nobody wins</td><td class="good">AI-managed single source of truth, always current</td></tr>
+          <tr><td>Reporting</td><td class="bad">Manual rebuild every single week</td><td class="good">AI-generated live dashboards, automated summaries</td></tr>
+          <tr><td>Approvals</td><td class="bad">Email threads, no tracking, no accountability</td><td class="good">AI-routed workflow, every decision logged</td></tr>
+          <tr><td>Permissions</td><td class="bad">Anyone can edit anything, anytime</td><td class="good">Role-based access, AI-enforced controlled views</td></tr>
+          <tr><td>Process knowledge</td><td class="bad">Lives in one person's head — until it doesn't</td><td class="good">AI-encoded in the system, accessible to everyone</td></tr>
         </tbody>
       </table>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>What we build to replace spreadsheets</h2>
+    <h2>What we build to replace spreadsheets — AI-powered from day one</h2>
     <div class="grid">
-      <div class="card"><h3>Job & Project Trackers</h3><p>Every job has a status, owner, and history. No spreadsheet required to know where things stand.</p></div>
-      <div class="card"><h3>Intake & Routing Systems</h3><p>New requests come in structured, get assigned automatically, and move through the process without manual triage.</p></div>
-      <div class="card"><h3>Approval Workflows</h3><p>Requests route to the right approver, decisions get logged, and nothing waits in a forgotten inbox.</p></div>
-      <div class="card"><h3>Field Team Apps</h3><p>Mobile-friendly apps for teams in the field — inspections, time tracking, job updates, photo capture.</p></div>
-      <div class="card"><h3>Reporting Dashboards</h3><p>Live views of the data that matters — no manual export, no Friday afternoon spreadsheet rebuild.</p></div>
-      <div class="card"><h3>Client & Project Portals</h3><p>Clients or internal teams see exactly what they need — filtered to their role and updated in real time.</p></div>
+      <div class="card"><h3>AI-Powered Job & Project Trackers</h3><p>Every job has an AI-managed status, clear owner, and full history. No spreadsheet required to know where things stand.</p></div>
+      <div class="card"><h3>AI-Managed Intake & Routing</h3><p>New requests come in structured, get AI-assigned automatically, and move through the process without any manual triage.</p></div>
+      <div class="card"><h3>AI-Driven Approval Workflows</h3><p>Requests AI-route to the right approver, decisions get logged, and nothing waits in a forgotten inbox again.</p></div>
+      <div class="card"><h3>AI-Enhanced Field Team Apps</h3><p>Mobile apps for field teams — AI-assisted inspections, time tracking, job updates, and photo capture from anywhere.</p></div>
+      <div class="card"><h3>AI-Generated Reporting Dashboards</h3><p>Live AI-powered views of the data that matters — no manual export, no Friday afternoon spreadsheet rescue mission.</p></div>
+      <div class="card"><h3>AI-Personalized Client Portals</h3><p>Clients and internal teams see exactly what they need — AI-filtered to their role and updated in real time.</p></div>
     </div>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Replace the Spreadsheet That Runs Your Business</h2>
-      <p>Tell us which spreadsheet is the most fragile part of your operation. We'll show you what a working system looks like in its place.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
+      <h2>Tell Us Which Spreadsheet Is the Most Fragile Part of Your Business</h2>
+      <p>We'll show you what an AI-powered custom app looks like in its place — and how fast we can build it before the next formula breaks and takes your data with it.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free AI Workflow Audit</a>
     </div>
     <div class="internal-links">
       <a href="/appsheet-consultant/">AppSheet Consulting →</a>

--- a/youros-home.html
+++ b/youros-home.html
@@ -76,7 +76,8 @@
     }
 
     .section {
-      padding: 4rem 0;
+      padding-top: 4rem;
+      padding-bottom: 4rem;
     }
 
     p+p {


### PR DESCRIPTION
## What's in this PR

5 new core money pages per the YourOS SEO architecture spec + updated homepage nav.

### New pages
- `/ai-automation-services-small-business/` — targets small businesses doing manual/repetitive work
- `/custom-workflow-automation/` — targets teams with broken handoffs and duct-taped processes
- `/replace-spreadsheets-with-custom-app/` — targets spreadsheet-dependent operations ready to upgrade
- `/appsheet-consultant/` — targets businesses looking for AppSheet help
- `/ai-assistants-for-business/` — targets teams that want AI embedded in their daily workflow

### Homepage update
- Refreshed nav with Services dropdown linking all 5 pages
- "Book a Workflow Audit" CTA button added to nav

### Page design
Each page follows the spec: one search intent, one pain, one promise, one CTA, internal cross-links to other money pages.

## Review checklist
- [ ] Page copy/tone feels right for the brand
- [ ] CTAs point to the right place (`/Begin-Your-Revolution.html`)
- [ ] Nav dropdown looks correct on mobile
- [ ] Ready to merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)