### PR TITLE
Standardize site footer messaging

### DIFF
--- a/Begin-Your-Revolution.html
+++ b/Begin-Your-Revolution.html
@@ -147,7 +147,48 @@
       vertical-align: middle;
       filter: invert(1);
     }
-</style>
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
+  </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -264,10 +305,12 @@
       </section>
     </div>
   </main>
-
   <footer>
     <div class="footer-inner">
-      <div>© 2026 YourOS. Built around the way your business actually works.</div>
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
       <div class="footer-links">
         <a href="/ai-automation-services-small-business/">AI Automation</a>
         <a href="/custom-workflow-automation/">Workflow Automation</a>
@@ -276,7 +319,6 @@
         <a href="/Begin-Your-Revolution.html">Book an Audit</a>
       </div>
     </div>
-    <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
   </footer>
 
   <script>

--- a/ai-assistants-for-business/index.html
+++ b/ai-assistants-for-business/index.html
@@ -46,6 +46,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -144,8 +185,21 @@
       <a href="/appsheet-consultant/">AppSheet Consulting →</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/ai-automation-services-small-business/index.html
+++ b/ai-automation-services-small-business/index.html
@@ -73,6 +73,47 @@
     .internal-links a:hover{border-color:var(--action);color:var(--action);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -193,8 +234,21 @@
       <a href="/appsheet-consultant/">AppSheet Consulting →</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/appsheet-consultant/index.html
+++ b/appsheet-consultant/index.html
@@ -45,6 +45,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -129,8 +170,21 @@
       <a href="/ai-assistants-for-business/">AI Assistants for Business →</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/blog/dashboard-design-best-practices/index.html
+++ b/blog/dashboard-design-best-practices/index.html
@@ -290,6 +290,47 @@
         font-size: 1.6rem;
       }
     }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -386,7 +427,21 @@
     <br><a class="cta" href="/Begin-Your-Revolution.html" target="_blank" rel="noopener">Begin Revolution</a>
   </section>
   <!-- FOOTER -->
-  <footer>© 2025 YourOS. Those who could excel, should excel <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon" class="favicon-footer"></a>
 
   <script>

--- a/blog/index.html
+++ b/blog/index.html
@@ -357,6 +357,47 @@
         font-size: 1.6rem;
       }
     }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -429,7 +470,21 @@
     <!-- add more <a class="post-card" href="#"> blocks in reverse chronological order -->
   </section>
   <!-- FOOTER -->
-  <footer>© 2025 YourOS. Those who could excel, should excel <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon"
     class="favicon-footer"></a>
 

--- a/blog/most-favorite-software-programs/index.html
+++ b/blog/most-favorite-software-programs/index.html
@@ -291,6 +291,47 @@
         font-size: 1.6rem;
       }
     }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -366,7 +407,21 @@
     <br><a class="cta" href="/Begin-Your-Revolution.html" target="_blank" rel="noopener">Book a Demo today</a>
   </section>
   <!-- FOOTER -->
-  <footer>© 2025 YourOS. Those who could excel, should excel <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon"
     class="favicon-footer"></a>
 

--- a/blog/software-adoption-secret/index.html
+++ b/blog/software-adoption-secret/index.html
@@ -291,6 +291,47 @@
         font-size: 1.6rem;
       }
     }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -387,7 +428,21 @@
     </div>
   </section>
   <!-- FOOTER -->
-  <footer>© 2025 YourOS. Those who could excel, should excel <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon"
     class="favicon-footer"></a>
 

--- a/custom-workflow-automation/index.html
+++ b/custom-workflow-automation/index.html
@@ -45,6 +45,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -130,8 +171,21 @@
       <a href="/appsheet-consultant/">AppSheet Consulting →</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/index.html
+++ b/index.html
@@ -224,6 +224,47 @@
       h1 { font-size: 2.1rem; }
       h2 { font-size: 1.6rem; }
     }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -393,8 +434,21 @@
       <p style="margin-top:0.75rem;font-size:0.85rem;color:var(--muted);">20 minutes to ditch BrokenOS — and become the ops hero of your team.</p>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
 
   <script>

--- a/lets-talk-ai.html
+++ b/lets-talk-ai.html
@@ -271,6 +271,47 @@
         flex-direction: column;
       }
     }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -360,8 +401,21 @@
     <a class="cta" href="Begin-Your-Revolution.html" target="_blank">Let's get Skyne-- I mean, a
       Sidekick!</a>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon"
     class="favicon-footer"></a>
 

--- a/pricing-competitors.html
+++ b/pricing-competitors.html
@@ -250,7 +250,48 @@
     h1 { font-size:2.25rem; }
     h2 { font-size:1.6rem; }
   }
-</style>
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
+  </style>
 
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -354,12 +395,20 @@
     </ul>
     <p>If those questions matter to you, let’s talk through the workflow and see what arrangement makes sense.</p>
   </section>
-
   <footer>
-    © 2025 YourOS. Those who could excel, should excel.
-    <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon"
-      class="favicon-footer"></a>
-    <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
   </footer>
 
   <script>

--- a/replace-spreadsheets-with-custom-app/index.html
+++ b/replace-spreadsheets-with-custom-app/index.html
@@ -50,6 +50,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}.compare-table{font-size:0.8rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -138,8 +179,21 @@
       <a href="/ai-automation-services-small-business/">AI Automation Services →</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/security-trust.html
+++ b/security-trust.html
@@ -270,6 +270,47 @@
         font-size: 1.6rem
       }
     }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
@@ -364,8 +405,21 @@
     <a class="cta" href="Begin-Your-Revolution.html" target="_blank" rel="noopener">Ditch the sticky
       notes on your desk</a>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS Favicon"
     class="favicon-footer"></a>
 

--- a/thank-you.html
+++ b/thank-you.html
@@ -25,6 +25,47 @@
     p { color: var(--muted); font-size:1.08rem; margin-bottom:1rem; }
     .next { margin-top:1.5rem; padding-top:1.5rem; border-top:1px solid var(--line); }
     .cta { display:inline-block; margin-top:.5rem; background:var(--action); color:white; padding:.85rem 1.15rem; border-radius:9px; }
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
 </head>
 
@@ -48,6 +89,21 @@
       </div>
     </section>
   </main>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
 </body>
 
 </html>

--- a/utah-ai-automation/index.html
+++ b/utah-ai-automation/index.html
@@ -68,6 +68,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -196,8 +237,21 @@
       <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/what-does-youros-do/index.html
+++ b/what-does-youros-do/index.html
@@ -73,6 +73,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -206,8 +247,21 @@
       <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/what-does-youros-do/stories-and-testimony/hvac.html
+++ b/what-does-youros-do/stories-and-testimony/hvac.html
@@ -48,6 +48,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -162,8 +203,21 @@
       <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/what-does-youros-do/stories-and-testimony/index.html
+++ b/what-does-youros-do/stories-and-testimony/index.html
@@ -75,6 +75,47 @@
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:768px){.case-grid{grid-template-columns:1fr;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -179,8 +220,21 @@
       <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/what-does-youros-do/stories-and-testimony/vehicle-track-to-backlog.html
+++ b/what-does-youros-do/stories-and-testimony/vehicle-track-to-backlog.html
@@ -50,6 +50,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}.highlight-box .big-stat{font-size:3rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -160,8 +201,21 @@
       <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/what-does-youros-do/stories-and-testimony/where-it-started.html
+++ b/what-does-youros-do/stories-and-testimony/where-it-started.html
@@ -46,6 +46,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -149,8 +190,21 @@
       <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>

--- a/what-does-youros-do/stories-and-testimony/whiteboard.html
+++ b/what-does-youros-do/stories-and-testimony/whiteboard.html
@@ -51,6 +51,47 @@
     .httl-mark{width:26px;height:auto;margin-left:0.85rem;opacity:0.55;vertical-align:middle;filter:invert(1);}
     @media(max-width:1280px){.nav-links{display:none;flex-direction:column;position:absolute;top:64px;right:1rem;background:var(--white);padding:1rem;box-shadow:0 4px 8px rgba(0,0,0,.1);border-radius:4px;max-width:calc(100vw - 2rem);box-sizing:border-box;}.nav-links.open{display:flex;}.nav-toggle{display:block;}.dropdown-content{position:static;box-shadow:none;display:none;margin-top:.35rem;min-width:0;width:100%;}.dropdown:hover .dropdown-content{display:block;}.dropdown-content a{white-space:normal;}}
     @media(max-width:640px){h1{font-size:2.1rem;}h2{font-size:1.6rem;}}
+
+    /* Standard site footer */
+    footer {
+      border-top: 1px solid var(--line);
+      background: rgba(0,0,0,.16);
+      color: var(--muted);
+      padding: 2rem 1.5rem;
+    }
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand-line {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      flex-wrap: wrap;
+    }
+    .footer-links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .footer-links a {
+      color: var(--muted);
+      font-size: .9rem;
+    }
+    .footer-links a:hover { color: var(--action); }
+    .httl-mark {
+      width: 26px;
+      height: auto;
+      opacity: .55;
+      vertical-align: middle;
+      filter: invert(1);
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y74BBJGYND"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-Y74BBJGYND');</script>
@@ -164,8 +205,21 @@
       <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Workflow Audit</a>
     </div>
   </section>
-
-  <footer>© 2025 YourOS. Those who could excel, should excel. <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord"></footer>
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-brand-line">
+        <span>© 2026 YourOS. Custom software and AI systems built around the way your business actually works.</span>
+        <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
+      </div>
+      <div class="footer-links">
+        <a href="/ai-automation-services-small-business/">AI Automation</a>
+        <a href="/custom-workflow-automation/">Workflow Automation</a>
+        <a href="/appsheet-consultant/">AppSheet Consulting</a>
+        <a href="/security-trust.html">Security</a>
+        <a href="/Begin-Your-Revolution.html">Book an Audit</a>
+      </div>
+    </div>
+  </footer>
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
   <script>const t=document.querySelector('.nav-toggle'),l=document.querySelector('.nav-links');if(t&&l)t.addEventListener('click',()=>l.classList.toggle('open'));</script>
 </body>


### PR DESCRIPTION
## Summary
- Standardize the footer across all HTML pages
- Replace the old 2025 brand line with: `© 2026 YourOS. Custom software and AI systems built around the way your business actually works.`
- Use one consistent footer layout with core service/security/audit links
- Preserve the subtle HTTL monogram in the footer
- Add the same footer to the thank-you page so it is consistent too

## Verification
- `git diff --check`
- Confirmed every HTML page has exactly one standardized footer and the old footer text is gone

## Note
Opened for review; not merged/deployed by TARS.
