### PR TITLE
[codex] Refresh site around growth systems positioning

### DIFF
--- a/Begin-Your-Revolution.html
+++ b/Begin-Your-Revolution.html
@@ -3,11 +3,11 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Book a Free Strategy Session – YourOS</title>
-  <meta name="description" content="Tell YourOS where your professional services firm is losing time to manual work, spreadsheets, reporting, or client follow-up drag. Book a free strategy session." />
+  <title>Start a Growth Systems Conversation – YourOS</title>
+  <meta name="description" content="Tell YourOS where growth is getting stuck in your service business. We will look for the practical growth system your business needs next." />
   <link rel="canonical" href="https://www.youros.app/begin-your-revolution" />
-  <meta property="og:title" content="Book a Free Strategy Session – YourOS" />
-  <meta property="og:description" content="Tell YourOS where your professional services firm is losing time to manual work, spreadsheets, reporting, or client follow-up drag. Book a free strategy session." />
+  <meta property="og:title" content="Start a Growth Systems Conversation – YourOS" />
+  <meta property="og:description" content="Tell YourOS where growth is getting stuck in your service business. We will look for the practical growth system your business needs next." />
   <meta property="og:image" content="https://i.postimg.cc/Bnrbwc51/Your-OS-Logo.png" />
   <meta property="og:url" content="https://www.youros.app/begin-your-revolution" />
   <meta property="og:type" content="website" />
@@ -223,15 +223,15 @@
       </div>
       <a href="https://www.youros.app/security-trust">Security &amp; Trust</a>
       <a href="/blog/">Blog</a>
-      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
   </nav>
 
   <main class="container">
     <section class="hero">
-      <span class="eyebrow">Free strategy session</span>
-      <h1>Find the workflow quietly costing your firm hours every week.</h1>
-      <p>Tell us where work is getting stuck — spreadsheets, handoffs, reporting, client follow-up, or communication drag. We will review it and respond with the best next step.</p>
+      <span class="eyebrow">Growth Systems Engineering</span>
+      <h1>Tell us where growth is getting stuck.</h1>
+      <p>Share the bottleneck, missed opportunity, or manual drag you keep running into. We will look for the practical growth system your business needs next.</p>
     </section>
 
     <section class="proof" aria-label="Real client outcomes">
@@ -260,22 +260,22 @@
 
     <div class="main-grid">
       <aside class="panel">
-        <h2>What we look for</h2>
-        <p class="muted">This is not a generic software demo. It is a practical first pass at the workflow that is costing your team time, money, or focus.</p>
+        <h2>What Growth Systems Engineers look for</h2>
+        <p class="muted">This is not a generic software demo. It is a practical first pass at the constraint slowing growth in your business.</p>
         <ul class="checklist">
-          <li>Where your team copies the same data between tools.</li>
-          <li>Which approvals, updates, or follow-ups are getting stuck.</li>
-          <li>Which spreadsheet or manual report has become a hidden payroll tax.</li>
-          <li>What should be automated, what should stay human, and what can be launched first.</li>
+          <li>Where leads, calls, quotes, appointments, or jobs lose momentum.</li>
+          <li>Which handoffs, updates, or follow-ups are getting stuck.</li>
+          <li>Which manual process has become a hidden tax on profit and capacity.</li>
+          <li>What should be systemized first, what should stay human, and what can be launched quickly.</li>
         </ul>
       </aside>
 
       <section class="panel form-card" aria-labelledby="audit-form-title">
-        <h2 id="audit-form-title">Book your free strategy session</h2>
-        <p class="muted">Four quick fields. No newsletter funnel. Just enough context to see whether automation or a custom app can help your firm.</p>
+        <h2 id="audit-form-title">Start a growth systems conversation</h2>
+        <p class="muted">Four quick fields. No newsletter funnel. Just enough context for us to see what kind of system might help.</p>
 
-        <form name="workflow-audit" method="POST" data-netlify="true" netlify-honeypot="bot-field" action="/thank-you.html">
-          <input type="hidden" name="form-name" value="workflow-audit">
+        <form name="growth-systems-conversation" method="POST" data-netlify="true" netlify-honeypot="bot-field" action="/thank-you.html">
+          <input type="hidden" name="form-name" value="growth-systems-conversation">
           <p class="hidden">
             <label>Do not fill this out if you are human: <input name="bot-field"></label>
           </p>
@@ -293,18 +293,18 @@
             <input id="phone" name="phone" type="tel" autocomplete="tel">
           </div>
           <div class="form-group">
-            <label for="problem">What is the biggest thing costing your team time right now?</label>
-            <textarea id="problem" name="problem" placeholder="Example: We rebuild the same report every Friday from three spreadsheets, then chase approvals by email." required></textarea>
+            <label for="problem">Where does growth feel stuck right now?</label>
+            <textarea id="problem" name="problem" placeholder="Example: We miss too many calls, quotes sit too long, appointments fall through, or our team keeps chasing the same updates by text and email." required></textarea>
           </div>
           <label for="sms-consent" style="display:flex;gap:.65rem;align-items:flex-start;font-size:.8rem;color:var(--muted);margin:.75rem 0 1rem;padding:.65rem .85rem;border:1px solid rgba(255,255,255,.1);border-radius:8px;line-height:1.55;">
             <input id="sms-consent" name="sms_consent" type="checkbox" value="yes" style="margin-top:.25rem;">
-            <span>I agree to receive SMS text messages from <strong style="color:var(--text);">YourOS / Spencer Jones</strong> related to my inquiry, scheduling, project status, and business follow-up communications. Message frequency varies based on my inquiry and project activity. Msg &amp; data rates may apply. Reply STOP to opt out at any time. Reply HELP for help. See our <a href="/privacy-policy.html#sms" style="color:var(--primary);">Privacy Policy</a> and <a href="/terms.html#sms" style="color:var(--primary);">SMS Terms</a>.</span>
+            <span>I agree to receive SMS text messages from <strong style="color:var(--text);">YourOS</strong> related to my inquiry, scheduling, project status, and business follow-up communications. Message frequency varies based on my inquiry and project activity. Msg &amp; data rates may apply. Reply STOP to opt out at any time. Reply HELP for help. See our <a href="/privacy-policy.html#sms" style="color:var(--primary);">Privacy Policy</a> and <a href="/terms.html#sms" style="color:var(--primary);">SMS Terms</a>.</span>
           </label>
-          <button type="submit" class="cta">Find My Workflow Bottleneck</button>
+          <button type="submit" class="cta">Start My Growth Systems Conversation</button>
         </form>
 
         <div class="next-steps">
-          <strong>What happens next:</strong> we review your workflow problem and you will hear back with a practical next step. If there is a fit, we will schedule a focused strategy call. If there is not a real automation opportunity, we will say that plainly.
+          <strong>What happens next:</strong> we review where growth is getting stuck and reply with a practical next step. If there is a fit, we will schedule a focused conversation. If there is not a real systems opportunity, we will say that plainly.
         </div>
       </section>
     </div>
@@ -312,7 +312,7 @@
   <footer>
     <div class="footer-inner">
       <div class="footer-brand-line">
-        <span>© 2026 YourOS. Work ON the business. Not just in it.</span>
+        <span>© 2026 YourOS. Growth Systems Engineering.</span>
         <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
       </div>
       <div class="footer-links">
@@ -320,7 +320,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
         <a href="/privacy-policy.html">Privacy Policy</a>
         <a href="/terms.html">Terms of Service</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>YourOS – Work ON Your Business, Not Just IN It</title>
-  <meta name="description" content="You work too much in the business and not enough on it. YourOS automates the work that distracts you — so you can focus on what actually matters." />
+  <title>YourOS – Work ON the Business With Growth Systems Engineering</title>
+  <meta name="description" content="YourOS helps growing service businesses work on the business instead of staying buried in it by finding and fixing the systems holding back growth." />
   <link rel="canonical" href="https://www.youros.app/" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="YourOS – Work ON Your Business, Not Just IN It" />
-  <meta property="og:description" content="You work too much in the business and not enough on it. YourOS automates the work that distracts you — so you can focus on what actually matters." />
+  <meta property="og:title" content="YourOS – Work ON the Business With Growth Systems Engineering" />
+  <meta property="og:description" content="YourOS helps growing service businesses work on the business instead of staying buried in it by finding and fixing the systems holding back growth." />
   <meta property="og:image" content="https://i.postimg.cc/Bnrbwc51/Your-OS-Logo.png" />
   <meta property="og:url" content="https://www.youros.app/" />
   <meta property="og:type" content="website" />
@@ -545,20 +545,20 @@
       <a href="https://www.youros.app/security-trust">Security & Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="/blog/">Blog</a>
-      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
   </nav>
 
   <!-- HERO -->
   <section class="hero">
-    <div class="hero-eyebrow">Serving Anywhere from Retail to Rentals to Repairs &amp; All Other Industries</div>
+    <div class="hero-eyebrow">Growth Systems Engineering</div>
     <img class="hero-logo" src="https://i.postimg.cc/Bnrbwc51/Your-OS-Logo.png" alt="YourOS Logo">
-    <h1>You’re probably here because you work too much <span class="word-in">IN</span> the business — and not enough <span class="word-on">ON</span> it.</h1>
-    <p class="hero-tagline">You’ve come to the right place.</p>
-    <p class="hero-bridge">You started this to build something. <strong>Not to be buried by it.</strong></p>
+    <h1>You're trying to grow the business. But you're still trapped working in it.</h1>
+    <p class="hero-tagline">Work on the business with Growth Systems Engineering.</p>
+    <p class="hero-bridge">We help growing service businesses operate like companies twice their size by finding and fixing the revenue leaks between lead, quote, appointment, and paid job.</p>
     <div class="cta-row">
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
-      <a class="cta-secondary" href="#why">See how it works ↓</a>
+      <a class="cta" href="/Begin-Your-Revolution.html">Start a Growth Systems Conversation</a>
+      <a class="cta-secondary" href="#why">See how we help ↓</a>
     </div>
   </section>
 
@@ -593,8 +593,8 @@
   <!-- COST OF INACTION -->
   <section class="cost-section">
     <div class="cost-inner">
-      <h2 class="cost-headline">You're <em>already paying</em> for this problem.</h2>
-      <p class="cost-sub">Every week you run without systems, the bill keeps adding up. It's just invisible — scattered across wasted hours, missed follow-ups, and a team stuck doing work a machine should be doing.</p>
+      <h2 class="cost-headline">You can feel the growth pressure before you can name the system problem.</h2>
+      <p class="cost-sub">You are trying to grow, but the business keeps pulling you back into calls, quotes, appointments, handoffs, reporting, follow-up, and daily cleanup. That is where the growth constraint usually shows itself first.</p>
 
       <div class="cost-grid">
         <div class="cost-card">
@@ -638,7 +638,7 @@
         </div>
       </div>
 
-      <p class="cost-sub" style="margin-bottom:0;">The question isn't whether you can afford to fix it. It's how long you can afford not to.</p>
+      <p class="cost-sub" style="margin-bottom:0;">The question is not which app you should buy. It is which system would let you work on the business again.</p>
       <p class="cost-source">Sources: <a href="https://asana.com/resources/anatomy-of-work" target="_blank" rel="noopener" style="color:inherit;">Asana Anatomy of Work Index</a> · <a href="https://www.mckinsey.com/featured-insights/future-of-work/jobs-lost-jobs-gained-what-the-future-of-work-will-mean-for-jobs-skills-and-wages" target="_blank" rel="noopener" style="color:inherit;">McKinsey Global Institute Automation Report</a></p>
     </div>
   </section>
@@ -647,8 +647,8 @@
   <section class="golden-section" id="why">
     <div class="golden-inner">
       <div class="golden-label label-why">Why</div>
-      <p class="golden-statement">We believe business owners should work more <em>on</em> the business — and less time <em style="color:var(--muted);font-style:normal;">in</em> it.</p>
-      <p class="golden-sub">You should be focused on what matters to <em style="color:var(--text);font-style:normal;font-weight:600;">you</em>. The vision. The clients. The next move. Not the same emails, the same approvals, the same fire drills that quietly steal your week. Freedom and focus aren’t a luxury — they’re the reason you started this.</p>
+      <p class="golden-statement">We believe business owners should be able to work on the business, not stay buried inside the business.</p>
+      <p class="golden-sub">Our history comes from solving real operational drag: field teams waiting on paperwork, locations running on whiteboards, owners chasing status, and teams losing growth capacity to handoffs nobody designed. Growth Systems Engineering turns those recurring problems into systems the business can actually run on.</p>
     </div>
   </section>
 
@@ -656,8 +656,8 @@
   <section class="golden-section" style="background:rgba(255,255,255,.015);">
     <div class="golden-inner">
       <div class="golden-label label-how">How</div>
-      <p class="golden-statement">We take the meaningless, redundant, and distracting work that still needs to get done — and we automate it and simplify how it gets executed.</p>
-      <p class="golden-sub">Not with bloated software that forces your team to change how they work. With systems built around the way your business actually runs — so the work that’s been draining your hours starts running itself, quietly, in the background.</p>
+      <p class="golden-statement">We find the growth constraint, then engineer the system that lets the business move without constant owner intervention.</p>
+      <p class="golden-sub">That might be phone-call handling, lead routing, quote follow-up, appointment protection, customer communication, reporting, AI agents, internal apps, or a cleaner workflow. The tool comes after the bottleneck is understood.</p>
     </div>
   </section>
 
@@ -665,17 +665,17 @@
   <section class="golden-section" id="services">
     <div class="golden-inner">
       <div class="golden-label label-what">What</div>
-      <p class="golden-statement">AI systems, workflows, integrations, and operational technology — built around your business.</p>
+      <p class="golden-statement">Growth Systems Engineering — built around the business you are actually trying to grow.</p>
       <div class="what-list">
-        <div class="what-item">Automations that take repetitive work off your plate</div>
-        <div class="what-item">AI built into the workflows you already use</div>
-        <div class="what-item">AI agents that act inside your tools</div>
-        <div class="what-item">Chatbots on your site that answer, qualify, and route</div>
-        <div class="what-item">Custom AI trained on your business</div>
-        <div class="what-item">Workflows designed around how you actually work</div>
-        <div class="what-item">The right technology for what you actually need</div>
-        <div class="what-item">More value from the tools you already pay for</div>
-        <div class="what-item">Clear, measurable ROI on every AI investment</div>
+        <div class="what-item">Phone-call and missed-call systems</div>
+        <div class="what-item">Lead intake, routing, and ownership</div>
+        <div class="what-item">Quote follow-up and next-step tracking</div>
+        <div class="what-item">Appointment reminders and no-show protection</div>
+        <div class="what-item">Customer communication and status updates</div>
+        <div class="what-item">Internal workflows designed around how you actually work</div>
+        <div class="what-item">AI agents and automation where they create leverage</div>
+        <div class="what-item">Reporting that shows where growth is getting stuck</div>
+        <div class="what-item">Practical technology chosen for the constraint</div>
       </div>
     </div>
   </section>
@@ -683,16 +683,16 @@
   <!-- CTA BLOCK -->
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Let’s get you back to running the business — not the other way around.</h2>
-      <p>One free conversation. We’ll find what’s stealing your time and map out exactly what a system can do about it.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html" style="font-size:1.1rem; padding:1.1rem 2.5rem;">Book a Free Strategy Session</a>
-      <p style="margin-top:0.75rem;font-size:0.85rem;color:var(--muted);">No pitch. No pressure. Just clarity.</p>
+      <h2>Start with the growth problem, not the software.</h2>
+      <p>Tell us where growth feels stuck. We will look for the system your business needs next and the simplest practical way to start.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html" style="font-size:1.1rem; padding:1.1rem 2.5rem;">Start a Growth Systems Conversation</a>
+      <p style="margin-top:0.75rem;font-size:0.85rem;color:var(--muted);">No generic software pitch. Just the next useful system.</p>
     </div>
   </section>
   <footer>
     <div class="footer-inner">
       <div class="footer-brand-line">
-        <span>© 2026 YourOS. Work ON the business. Not just in it.</span>
+        <span>© 2026 YourOS. Growth Systems Engineering.</span>
         <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
       </div>
       <div class="footer-links">
@@ -700,7 +700,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
         <a href="/privacy-policy.html">Privacy Policy</a>
         <a href="/terms.html">Terms of Service</a>
       </div>
@@ -709,9 +709,9 @@
   <a href="https://www.youros.app"><img src="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" alt="YourOS" class="favicon-footer"></a>
 
   <script>
-    const toggle = document.querySelector(‘.nav-toggle’);
-    const links = document.querySelector(‘.nav-links’);
-    if (toggle && links) toggle.addEventListener(‘click’, () => links.classList.toggle(‘open’));
+    const toggle = document.querySelector('.nav-toggle');
+    const links = document.querySelector('.nav-links');
+    if (toggle && links) toggle.addEventListener('click', () => links.classList.toggle('open'));
   </script>
 </body>
 </html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -3,8 +3,8 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Strategy Session Request Received – YourOS</title>
-  <meta name="description" content="YourOS received your strategy session request. We will review the workflow problem and respond with the best next step." />
+  <title>Growth Systems Request Received – YourOS</title>
+  <meta name="description" content="YourOS received your growth systems request. We will review where growth is getting stuck and respond with the best next step." />
   <meta name="robots" content="noindex, follow" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="https://i.postimg.cc/438dsJnm/3-D-Electric-Blue-Y-with-Chrome-Line.png" type="image/png">
@@ -81,10 +81,10 @@
   <main>
     <section class="panel">
       <span class="eyebrow">Request received</span>
-      <h1>We have your workflow problem.</h1>
+      <h1>We have your growth systems request.</h1>
       <p>Thanks for sending it over. We will review what you shared and respond with the best next step.</p>
       <div class="next">
-        <p>If there is a real automation opportunity, we will schedule a focused strategy session. If not, we will tell you plainly instead of pushing a bad-fit project.</p>
+        <p>If there is a real systems opportunity, we will schedule a focused conversation. If not, we will tell you plainly instead of pushing a bad-fit project.</p>
         <a class="cta" href="/">Back to YourOS</a>
       </div>
     </section>
@@ -92,7 +92,7 @@
   <footer>
     <div class="footer-inner">
       <div class="footer-brand-line">
-        <span>© 2026 YourOS. Work ON the business. Not just in it.</span>
+        <span>© 2026 YourOS. Growth Systems Engineering.</span>
         <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
       </div>
       <div class="footer-links">
@@ -100,7 +100,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
         <a href="/privacy-policy.html">Privacy Policy</a>
         <a href="/terms.html">Terms of Service</a>
       </div>

--- a/what-does-youros-do/index.html
+++ b/what-does-youros-do/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>What Does YourOS Do? – Custom Workflow Systems for Small Business</title>
-  <meta name="description" content="YourOS builds custom workflow systems, AI automations, and internal apps around how your business actually works. No templates. No bloatware. Just your process, operationalized." />
+  <title>What Does YourOS Do? – Growth Systems Engineering</title>
+  <meta name="description" content="YourOS helps growing service businesses find the constraint slowing growth, then designs practical systems around calls, leads, quotes, appointments, workflows, and reporting." />
   <link rel="canonical" href="https://www.youros.app/what-does-youros-do/" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="What Does YourOS Do? – Custom Workflow Systems for Small Business" />
-  <meta property="og:description" content="YourOS builds custom workflow systems, AI automations, and internal apps around how your business actually works. No templates. No bloatware." />
+  <meta property="og:title" content="What Does YourOS Do? – Growth Systems Engineering" />
+  <meta property="og:description" content="YourOS helps growing service businesses find the constraint slowing growth, then designs practical systems around calls, leads, quotes, appointments, workflows, and reporting." />
   <meta property="og:image" content="https://i.postimg.cc/Bnrbwc51/Your-OS-Logo.png" />
   <meta property="og:url" content="https://www.youros.app/what-does-youros-do/" />
   <meta property="og:type" content="website" />
@@ -144,51 +144,51 @@
       <a href="https://www.youros.app/security-trust">Security &amp; Trust</a>
       <a href="https://www.youros.app/lets-talk-ai">Let's Talk AI</a>
       <a href="/blog/">Blog</a>
-      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
   </nav>
 
   <!-- HERO -->
   <section class="hero">
-    <div class="hero-eyebrow">Custom Systems · AI Automation · AppSheet</div>
-    <h1>We Build the System Your Business Has Always Needed</h1>
-    <p>YourOS doesn't sell software. We map how your team actually works, then build a custom operating system around it — faster than off-the-shelf, smarter than a spreadsheet, and built to grow with you.</p>
+    <div class="hero-eyebrow">Growth Systems Engineering</div>
+    <h1>We Find the System Your Business Needs to Grow</h1>
+    <p>YourOS helps growing service businesses operate like companies twice their size by finding and fixing the revenue leaks between lead, quote, appointment, and paid job. Software, automation, and AI are tools. Growth is the point.</p>
   </section>
 
   <!-- SERVICES -->
   <section class="section wrapper">
-    <h2>What We Build</h2>
-    <p style="color:var(--muted);">Five service areas. One goal: replace the manual work that's costing your team time every single day.</p>
+    <h2>Where Growth Systems Show Up</h2>
+    <p style="color:var(--muted);">We start with the business constraint, then choose the practical system that removes it.</p>
     <div class="services-grid">
       <div class="service-card">
-        <h3>⚡ AI Workflow Automation</h3>
-        <p>We identify the repetitive manual steps in your workflow and build automations that run them for you — intake, routing, follow-up, reminders, handoffs. All connected to the tools you already use.</p>
-        <a href="/ai-automation-services-small-business/">Learn more about AI Automation →</a>
+        <h3>Phone Call Systems</h3>
+        <p>Missed-call recovery, call routing, summaries, callbacks, appointment capture, and follow-up systems for businesses where phone conversations still drive growth.</p>
+        <a href="/Begin-Your-Revolution.html">Talk about phone calls →</a>
       </div>
       <div class="service-card">
-        <h3>🔧 Custom Workflow Systems</h3>
-        <p>Turn scattered processes into clean, automated workflows. Every step has an owner. Status is visible. Work stops falling through cracks between tools or people.</p>
-        <a href="/custom-workflow-automation/">Learn more about Custom Workflows →</a>
+        <h3>Lead and Quote Movement</h3>
+        <p>Every lead gets an owner. Every quote gets a next step. Opportunities stop disappearing between the first conversation and the paid job.</p>
+        <a href="/Begin-Your-Revolution.html">Find the stuck point →</a>
       </div>
       <div class="service-card">
-        <h3>📊 Replace Spreadsheets</h3>
-        <p>We turn fragile spreadsheets into custom apps that track work, enforce process, eliminate version confusion, and give your team one shared source of truth.</p>
-        <a href="/replace-spreadsheets-with-custom-app/">Learn more about Replacing Spreadsheets →</a>
+        <h3>Appointment and Job Protection</h3>
+        <p>Reminders, confirmations, status updates, and handoffs that protect booked work from no-shows, confusion, and last-minute chaos.</p>
+        <a href="/Begin-Your-Revolution.html">Protect booked work →</a>
       </div>
       <div class="service-card">
-        <h3>📱 AppSheet Consulting</h3>
-        <p>Custom internal apps, live dashboards, approval flows, and field-team tools built on Google AppSheet — connected to your Workspace, your data, your process.</p>
-        <a href="/appsheet-consultant/">Learn more about AppSheet Consulting →</a>
+        <h3>Internal Operating Systems</h3>
+        <p>Custom workflows, apps, dashboards, approvals, and field-team tools that give the business one shared way to see and move work.</p>
+        <a href="/custom-workflow-automation/">See workflow systems →</a>
       </div>
       <div class="service-card">
-        <h3>🤖 AI Assistants for Business</h3>
-        <p>AI sidekicks that summarize, draft, route, search, and act inside the systems your business already uses. Practical, measurable impact — not science fair projects.</p>
-        <a href="/ai-assistants-for-business/">Learn more about AI Assistants →</a>
+        <h3>AI and Automation Leverage</h3>
+        <p>AI agents, assistants, automations, and integrations used only where they create real leverage in the growth system.</p>
+        <a href="/ai-assistants-for-business/">See AI assistants →</a>
       </div>
       <div class="service-card">
-        <h3>📍 Utah AI Consulting</h3>
-        <p>Local to the Wasatch Front. We work with businesses across Salt Lake City, Tooele County, and surrounding areas to build practical AI operating systems.</p>
-        <a href="/utah-ai-automation/">Learn more about Utah AI Consulting →</a>
+        <h3>Reporting and Visibility</h3>
+        <p>Simple reporting that shows where growth is moving, where it is stuck, and what needs attention before profit leaks away quietly.</p>
+        <a href="/Begin-Your-Revolution.html">Show us the bottleneck →</a>
       </div>
     </div>
   </section>
@@ -196,13 +196,13 @@
   <!-- HOW IT WORKS -->
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2 style="text-align:center;">How It Works</h2>
-      <p style="text-align:center;color:var(--muted);max-width:520px;margin:0.5rem auto 0;">Four steps from broken process to running system. No six-month timelines. No enterprise bloat.</p>
+      <h2 style="text-align:center;">How Growth Systems Engineering Works</h2>
+      <p style="text-align:center;color:var(--muted);max-width:560px;margin:0.5rem auto 0;">The offer is conversation-first right now: understand the constraint, choose the smallest useful system, then productize the patterns that repeat.</p>
       <div class="process-steps">
-        <div class="step"><div class="step-num">1</div><h3>Workflow Audit</h3><p>We map your manual steps, spreadsheet risks, and automation opportunities in one short session.</p></div>
-        <div class="step"><div class="step-num">2</div><h3>Build</h3><p>We design and build a custom system around your workflow — not a template someone else designed.</p></div>
-        <div class="step"><div class="step-num">3</div><h3>Launch</h3><p>We deploy fast, train your team, and make sure the process actually runs the way it should.</p></div>
-        <div class="step"><div class="step-num">4</div><h3>Iterate</h3><p>We improve, automate more, and keep the system aligned as your business changes and grows.</p></div>
+        <div class="step"><div class="step-num">1</div><h3>Talk</h3><p>You explain where growth is getting stuck and what you are trying to make happen.</p></div>
+        <div class="step"><div class="step-num">2</div><h3>Diagnose</h3><p>We look for the constraint behind the symptoms: calls, follow-up, workflow, visibility, or capacity.</p></div>
+        <div class="step"><div class="step-num">3</div><h3>Engineer</h3><p>We design the simplest practical system that can remove the constraint and prove value.</p></div>
+        <div class="step"><div class="step-num">4</div><h3>Grow</h3><p>We improve the system as real usage reveals the next bottleneck or productized opportunity.</p></div>
       </div>
     </div>
   </section>
@@ -242,15 +242,15 @@
   <!-- CTA -->
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Show Us the Workflow That's Costing You the Most Time</h2>
-      <p>In one 20-minute session, we'll map your manual steps, surface the biggest automation opportunity, and show you exactly what a working system looks like in your workflow.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <h2>Show Us Where Growth Is Getting Stuck</h2>
+      <p>Start with a conversation. We will help identify what kind of growth system would move the business forward.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Start a Growth Systems Conversation</a>
     </div>
   </section>
   <footer>
     <div class="footer-inner">
       <div class="footer-brand-line">
-        <span>© 2026 YourOS. Work ON the business. Not just in it.</span>
+        <span>© 2026 YourOS. Growth Systems Engineering.</span>
         <img class="httl-mark" src="/img/httl-monogram.png" alt="Holiness To The Lord" title="Holiness To The Lord">
       </div>
       <div class="footer-links">
@@ -258,7 +258,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## What changed
- Repositioned the homepage around Growth Systems Engineering and Growth Systems Expert language.
- Kept the core service-business message about operating like companies twice their size and fixing revenue leaks between lead, quote, appointment, and paid job.
- Reworked the contact path from a fixed audit/strategy-session frame into a conversation-first Growth Systems request.
- Updated the What Does YourOS Do and thank-you pages so the funnel matches the new positioning.

## Why
Spencer's recent conversations show Growth Systems Engineer / Growth Systems Expert is resonating better than custom software, AI, or revenue-only language. The site should create qualified conversations before locking into a specific product ladder.

## Notes
This is Phase 1 only: messaging and CTA framing. It intentionally does not add Revenue Leak Scan, a 7-day audit, a fixed offer ladder, pricing, or a BizTech product page yet.

## Validation
- `git diff --check`
- Local static preview with `python3 -m http.server 4173`
- Playwright screenshots for homepage, mobile contact page, What Does YourOS Do, and thank-you page
