### PR TITLE
Fix blog index: remove old post cards left over from PR #60

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -449,24 +449,6 @@
 
   <!-- POSTS LIST -->
   <section class="section wrapper posts-grid">
-    <a class="post-card" href="/blog/most-favorite-software-programs/">
-      <h2>What are the most favorite software programs?</h2>
-      <p class="muted">July 20, 2025 — Productivity</p>
-      <p>A quick tour of the tools users rave about, from classic utilities to new productivity powerhouses.</p>
-
-    </a>
-    <a class="post-card" href="/blog/dashboard-design-best-practices/">
-      <h2>Dashboard Design Is Not About Looking Clean</h2>
-      <p class="muted">Refreshed May 2026 — Ops</p>
-      <p>A good dashboard is not the cleanest screen. It is the one that helps operators make the right move faster.</p>
-
-    </a>
-    <a class="post-card" href="/blog/software-adoption-secret/">
-      <h2>What is the secret to successful software adoption?</h2>
-      <p class="muted">July 12, 2025 — Logistics</p>
-      <p>Feel like no on is using the system right? Discover our game-changing secret to user adoption that transforms frustration into success. Learn why at Your OS, we found the perfect harmony between user and stakeholder—unlocking productivity, boosting morale, and delivering software your team WANTS to use.</p>
-
-    </a>
     <!-- add more <a class="post-card" href="#"> blocks in reverse chronological order -->
   </section>
   <!-- FOOTER -->


### PR DESCRIPTION
## Summary

- PR #60 deleted the 3 blog post directories but left the hardcoded `<a class="post-card">` links in `blog/index.html`
- The live site was still rendering all 3 old posts (with dead links to 404 pages)
- This removes the 3 post card blocks, leaving the index as a clean empty shell ready for Dominic's content

## What's left

The `blog/index.html` structure (hero, grid container, nav, footer) is fully intact — just no post cards until new content is added.

🤖 Generated with TARS / Claude Code