### PR TITLE
Message audit Scope #2: rewrite 4 OFF-message SEO landing pages with GSE framing

### DIFF
--- a/ai-assistants-for-business/index.html
+++ b/ai-assistants-for-business/index.html
@@ -110,13 +110,13 @@
         <div class="dropdown-content"><a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a></div>
       </div>
       <a href="/blog/">Blog</a>
-      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">Custom AI Assistants for Business</div>
-    <h1>Give Every Person on Your Team an AI-Powered Assistant Working Behind Them</h1>
+    <div class="hero-eyebrow">Growth Systems Engineering · Practical AI</div>
+    <h1>Give Every Person on Your Team a Custom AI Sidekick Working Behind Them</h1>
     <p>We build custom AI assistants that serve your team inside the systems your business already uses — grounded in your real data, built around your real workflow. Your people get more done, scale faster, and stay focused on the work that actually takes a human. Not AI theater. Practical AI that earns its place by serving the people who run your business.</p>
     <a class="cta" href="/Begin-Your-Revolution.html">See What an AI Sidekick Does for You</a>
   </section>
@@ -124,61 +124,61 @@
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › AI Assistants for Business</div>
     <h2>What a custom AI assistant does for your team — so your team can do what they're actually good at</h2>
-    <p>Think of it as giving every person on your team a dedicated AI-powered assistant working behind them. The AI handles the repetitive knowledge work. Your people get their hours back — and the space to do the work that actually takes a human.</p>
+    <p>The assistant handles the repetitive knowledge work that was eating their week. Your people get their hours back — and the space to do the work that actually takes a human.</p>
     <ul class="check-list">
-      <li>AI-powered job update and customer thread summaries — in seconds, not 20 minutes of reading</li>
-      <li>AI-drafted responses, follow-ups, and status reports — ready to review and send, not built from scratch</li>
-      <li>AI-answered internal questions from your own data, SOPs, and records — not guesses from the open internet</li>
-      <li>AI-prepared weekly reports — generated and delivered automatically, no manual building required</li>
-      <li>AI-spotted missing information — flagged before it causes a downstream problem, not after</li>
-      <li>AI-managed request routing — incoming work assigned to the right person or queue without manual triage</li>
+      <li>Job update and customer thread summaries — in seconds, not 20 minutes of reading</li>
+      <li>Drafted responses, follow-ups, and status reports — ready to review and send, not built from scratch</li>
+      <li>Internal questions answered from your own data, SOPs, and records — not guesses from the open internet</li>
+      <li>Weekly reports prepared — generated and delivered automatically, no manual building required</li>
+      <li>Missing information flagged — caught before it causes a downstream problem, not after</li>
+      <li>Request routing — incoming work assigned to the right person or queue without manual triage</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
       <h2>Why most AI assistant deployments fail — and what we do differently</h2>
-      <p>Most AI implementations fail not because the AI is bad — but because the foundation isn't there. AI amplifies what's already in your data. If the data is messy, the AI output will be messier. If the process is broken, AI accelerates the chaos.</p>
+      <p>Most AI implementations fail not because the AI is bad — but because the foundation isn't there. AI amplifies what's already in your data. If the data is messy, the output will be messier. If the process is broken, AI accelerates the chaos.</p>
       <ul class="warning-list">
-        <li>Bad data — garbage in, garbage out. AI-powered assistants need clean, structured data or they make things up.</li>
-        <li>Undefined processes — AI-powered automation can't run a workflow nobody has clearly defined yet</li>
-        <li>No permissions model — AI acting on uncontrolled data creates liability and risk, not efficiency</li>
-        <li>No source of truth — AI will hallucinate confidently when it can't find a real, grounded answer</li>
-        <li>No human approval layer — unsupervised AI-powered actions compound mistakes faster than humans can</li>
+        <li>Bad data — garbage in, garbage out. An assistant needs clean, structured data or it makes things up.</li>
+        <li>Undefined processes — automation can't run a workflow nobody has clearly defined yet</li>
+        <li>No permissions model — an AI acting on uncontrolled data creates liability and risk, not efficiency</li>
+        <li>No source of truth — the assistant will hallucinate confidently when it can't find a real, grounded answer</li>
+        <li>No human approval layer — unsupervised actions compound mistakes faster than your team can catch them</li>
       </ul>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>Why YourOS builds the AI-ready foundation first</h2>
-    <p>We don't drop an AI-powered assistant on top of a broken process. We build the clean system underneath it first — then add AI where it genuinely multiplies your team's output.</p>
+    <h2>Why YourOS engineers the foundation first</h2>
+    <p>We don't drop an assistant on top of a broken process. We build the clean system underneath it first — then add AI where it genuinely multiplies your team's output. This is Growth Systems Engineering applied to AI: system before sidekick, always.</p>
     <ul class="check-list">
-      <li>AI-ready clean data — structured inputs, validated fields, one source of AI-accessible truth</li>
-      <li>Clearly defined AI-enhanced workflow — every step mapped and confirmed before AI is layered on</li>
-      <li>AI-suggested, human-approved actions — AI recommends, humans decide where consequences are real</li>
-      <li>AI grounded in your actual records — pulls from your AppSheet systems and real data, not the open internet</li>
+      <li>Clean, structured data — inputs validated, one source of truth the assistant can actually trust</li>
+      <li>Clearly defined workflow — every step mapped and confirmed before AI is layered on</li>
+      <li>Suggested, human-approved actions — the assistant recommends, your team decides where consequences are real</li>
+      <li>Grounded in your actual records — pulls from your AppSheet systems and real data, not the open internet</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>AI-powered sidekicks we build for real business workflows</h2>
+      <h2>Sidekicks we build for real business workflows</h2>
       <div class="grid">
-        <div class="card"><h3>AI-Powered Operations Sidekick</h3><p>AI monitors job status, flags overdue items, and summarizes daily activity — so the ops manager focuses on fixing problems, not finding them.</p></div>
-        <div class="card"><h3>AI-Driven Sales Follow-up Sidekick</h3><p>AI drafts follow-up messages, tracks where each lead stands, and alerts the team before opportunities go cold and stay there.</p></div>
-        <div class="card"><h3>AI-Generated Reporting Sidekick</h3><p>AI pulls live data from your AppSheet system and generates formatted summaries — weekly, daily, or the moment you ask.</p></div>
-        <div class="card"><h3>AI-Powered Customer Intake Sidekick</h3><p>AI parses incoming requests, extracts what matters, routes to the right team, and drafts the first response — faster than any human triage.</p></div>
-        <div class="card"><h3>AI-Enhanced Admin Sidekick</h3><p>AI handles scheduling questions, document lookups, and internal FAQ — freeing admin staff for the work that actually needs a person.</p></div>
-        <div class="card"><h3>AI-Assisted Field Team Sidekick</h3><p>AI gives field staff instant mobile access to job history, customer notes, and SOPs — no digging through old emails or broken spreadsheets.</p></div>
+        <div class="card"><h3>Operations Sidekick</h3><p>Monitors job status, flags overdue items, and summarizes daily activity — so the ops manager focuses on fixing problems, not finding them.</p></div>
+        <div class="card"><h3>Sales Follow-up Sidekick</h3><p>Drafts follow-up messages, tracks where each lead stands, and alerts the team before opportunities go cold and stay there.</p></div>
+        <div class="card"><h3>Reporting Sidekick</h3><p>Pulls live data from your AppSheet system and generates formatted summaries — weekly, daily, or the moment you ask.</p></div>
+        <div class="card"><h3>Customer Intake Sidekick</h3><p>Parses incoming requests, extracts what matters, routes to the right team, and drafts the first response — faster than any human triage.</p></div>
+        <div class="card"><h3>Admin Sidekick</h3><p>Handles scheduling questions, document lookups, and internal FAQ — freeing admin staff for the work that actually needs a person.</p></div>
+        <div class="card"><h3>Field Team Sidekick</h3><p>Gives field staff instant mobile access to job history, customer notes, and SOPs — no digging through old emails or broken spreadsheets.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Find Out Where an AI-Powered Sidekick Would Save Your Team the Most Time</h2>
-      <p>We'll map the low-value knowledge work your team does every day, identify exactly where AI-powered automation would save the most hours, and show you what a working AI assistant looks like in your workflow.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <h2>Find Out Where a Custom Sidekick Would Save Your Team the Most Time</h2>
+      <p>We'll map the low-value knowledge work your team does every day, identify exactly where a well-built assistant would save the most hours, and show you what one looks like in your workflow. If the foundation isn't ready yet, we'll tell you that too — and what to build first.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
     <div class="internal-links">
       <a href="/ai-automation-services-small-business/">AI Automation Services →</a>
@@ -197,7 +197,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
       </div>
     </div>
   </footer>

--- a/ai-automation-services-small-business/index.html
+++ b/ai-automation-services-small-business/index.html
@@ -144,26 +144,26 @@
         </div>
       </div>
       <a href="/blog/">Blog</a>
-      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">AI-Powered Automation Services</div>
-    <h1>Your Team Is Spending 8+ Hours a Week on Work AI Can Eliminate</h1>
-    <p>We audit your workflow, identify exactly where AI can serve your team, and build AI-powered automation systems that give every person on your team the leverage of three — without adding headcount, training time, or payroll risk.</p>
-    <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+    <div class="hero-eyebrow">Growth Systems Engineering · Automation</div>
+    <h1>Your Team Is Spending 8+ Hours a Week on Work Your Business Could Engineer Away</h1>
+    <p>We audit your workflow, identify exactly where automation earns its place, and engineer the systems that give every person on your team the leverage they need — without adding headcount, training time, or payroll risk.</p>
+    <a class="cta" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › AI Automation Services</div>
     <h2>Signs your team is stuck doing work that was never worth their talent</h2>
-    <p>Your people were hired to think, build, serve, and grow — not to copy data, chase updates, and rebuild the same report every Friday. Every item below is work AI should be doing for them, so they can do the work only they can do.</p>
+    <p>Your people were hired to think, build, serve, and grow — not to copy data, chase updates, and rebuild the same report every Friday. Every item below is work the system should be doing, so they can do the work only they can do.</p>
     <ul class="check-list">
       <li>Staff copying data between tools every single morning</li>
       <li>Weekly reports built by hand, every Friday, from scratch</li>
       <li>Customers waiting because follow-up is still a manual task on someone's to-do list</li>
-      <li>Managers chasing status updates instead of getting AI-managed notifications automatically</li>
+      <li>Managers chasing status updates instead of getting them automatically</li>
       <li>The same information entered in multiple places by multiple people</li>
       <li>Approvals sitting in email threads nobody checks — or remembers</li>
     </ul>
@@ -171,22 +171,22 @@
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>What AI handles for your team — so your team can handle what matters</h2>
-      <p>Think of it as giving every person on your team a dedicated AI-powered assistant working behind them. These are the tasks that assistant owns — so your people don't have to.</p>
+      <h2>What the system handles — so your team can focus on what matters</h2>
+      <p>These are the steps the engineered system owns end-to-end. Where AI earns its place — parsing, classification, drafting — it goes inside the system as a tool, not on top of it as marketing.</p>
       <div class="grid">
-        <div class="card"><h3>AI-Managed Intake & Routing</h3><p>New requests arrive and get AI-routed to the right person or queue automatically — zero manual triage, zero dropped balls.</p></div>
-        <div class="card"><h3>AI-Powered Follow-up Sequences</h3><p>Nothing falls through because a person forgot. AI-managed follow-up sequences run on schedule, every time, without reminders.</p></div>
-        <div class="card"><h3>AI-Generated Reporting</h3><p>Weekly reports that used to take hours get AI-generated and delivered to your team — no Friday spreadsheet rescue missions.</p></div>
-        <div class="card"><h3>AI-Assisted Data Entry & Cleanup</h3><p>Messy incoming data gets AI-structured and entered once — not re-entered three times across disconnected tools.</p></div>
-        <div class="card"><h3>AI-Tracked Workflow Handoffs</h3><p>Work moves step to step with a clear owner and AI-updated status — no more "where is this at?" holding up your day.</p></div>
-        <div class="card"><h3>AI-Driven Document Processing</h3><p>Incoming documents get parsed, classified, and acted on by AI — without someone reading and re-typing every single one.</p></div>
+        <div class="card"><h3>Intake & Routing</h3><p>New requests arrive and get routed to the right person or queue automatically — zero manual triage, zero dropped balls.</p></div>
+        <div class="card"><h3>Follow-up Sequences</h3><p>Nothing falls through because a person forgot. Follow-up sequences run on schedule, every time, without reminders.</p></div>
+        <div class="card"><h3>Reporting on Schedule</h3><p>Weekly reports that used to take hours get generated and delivered automatically — no Friday spreadsheet rescue missions.</p></div>
+        <div class="card"><h3>Data Entry & Cleanup</h3><p>Messy incoming data gets structured and entered once — not re-entered three times across disconnected tools.</p></div>
+        <div class="card"><h3>Workflow Handoffs</h3><p>Work moves step to step with a clear owner and visible status — no more "where is this at?" holding up your day.</p></div>
+        <div class="card"><h3>Document Processing</h3><p>Incoming documents get parsed, classified, and acted on — without someone reading and re-typing every single one.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>AI automates the repetitive. Humans handle what actually matters.</h2>
-    <p>Good AI-powered automation doesn't replace your team — it gives them back the hours they're currently losing to low-value work. Here's what stays human:</p>
+    <h2>Engineered systems handle the repetitive. Your team handles what actually matters.</h2>
+    <p>Well-built automation gives your people back the hours they're currently losing to low-value work. Here's what stays with them by design:</p>
     <ul class="check-list">
       <li>Final approvals on decisions that carry real consequences</li>
       <li>Relationship-heavy customer conversations that need empathy, not efficiency</li>
@@ -197,14 +197,14 @@
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>How our AI-powered workflow audit works</h2>
-      <p>We don't drop an AI tool on your team and disappear. We map your real workflow first, then build AI automation around what's actually happening — not what someone assumed was happening.</p>
+      <h2>How our workflow audit works</h2>
+      <p>We don't drop a tool on your team and disappear. We map your real workflow first, then engineer automation around what's actually happening — not what someone assumed was happening.</p>
       <ul class="check-list">
-        <li>AI workflow audit first — we identify every manual step before writing a single line of automation</li>
-        <li>AI-automate the repeatable — the steps that happen the same way every time are the ones AI owns</li>
-        <li>Add AI intelligence only where it earns its place — not where it adds complexity for complexity's sake</li>
-        <li>Keep humans in the loop — AI-powered approval flows, overrides, and real-time visibility built in from day one</li>
-        <li>Built on AppSheet and Google Cloud — AI-enhanced systems your team can actually run without an IT department</li>
+        <li>Workflow audit first — we identify every manual step before writing a single line of automation</li>
+        <li>Automate the repeatable — the steps that happen the same way every time are the ones the system owns</li>
+        <li>Add intelligence only where it earns its place — not where it adds complexity for complexity's sake</li>
+        <li>Keep your team in the loop — approval flows, overrides, and real-time visibility built in from day one</li>
+        <li>Built on AppSheet and Google Cloud — engineered systems your team can actually run without an IT department</li>
       </ul>
     </div>
   </section>
@@ -212,11 +212,11 @@
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
       <h2>Scale your capacity without scaling your payroll</h2>
-      <p>Hiring is expensive, slow, and risky. Training takes months. And when someone leaves, they take the process with them. AI-powered automation gives your business a different path to growth.</p>
+      <p>Hiring is expensive, slow, and risky. Training takes months. And when someone leaves, they take the process with them. Engineered automation gives your business a different path to growth.</p>
       <ul class="check-list">
         <li>Your current team handles 2x the volume — without overtime, burnout, or a new hire</li>
-        <li>New team members ramp up in days, not months — because the AI-powered system guides the process</li>
-        <li>You scale the repetitive work instantly — the AI scales with you, your headcount doesn't have to</li>
+        <li>New team members ramp up in days, not months — because the system guides the process</li>
+        <li>You scale the repetitive work instantly — the system scales with you, your headcount doesn't have to</li>
         <li>Your people stay in roles that actually use their skills — which means they stay, period</li>
       </ul>
     </div>
@@ -224,9 +224,9 @@
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Find Out Where AI Can Give Your Team the Most Leverage</h2>
-      <p>In one focused session, we map your workflow, surface the AI-automation opportunities, and show you exactly how to expand what your team can accomplish — without adding headcount.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <h2>Find Out Where Engineered Automation Gives Your Team the Most Leverage</h2>
+      <p>In one focused conversation, we map your workflow, surface the leverage points, and show you exactly how to expand what your team can accomplish — without adding headcount.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
     <div class="internal-links">
       <a href="/custom-workflow-automation/">Custom Workflow Automation →</a>
@@ -246,7 +246,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
       </div>
     </div>
   </footer>

--- a/appsheet-consultant/index.html
+++ b/appsheet-consultant/index.html
@@ -109,61 +109,61 @@
         <div class="dropdown-content"><a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a></div>
       </div>
       <a href="/blog/">Blog</a>
-      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">AI-Powered AppSheet Consulting</div>
-    <h1>Expert AppSheet Consultants Who Build AI-Enhanced Business Apps in Weeks, Not Months</h1>
-    <p>We build AI-powered AppSheet systems that replace your spreadsheets, automate your operations, and connect with the Google Workspace tools your team already uses — without the cost or complexity of enterprise software.</p>
+    <div class="hero-eyebrow">Growth Systems Engineering · AppSheet</div>
+    <h1>AppSheet Consultants Who Engineer Business Systems in Weeks, Not Months</h1>
+    <p>We build AppSheet systems that replace your spreadsheets, organize your operations, and connect with the Google Workspace tools your team already uses — without the cost or complexity of enterprise software.</p>
     <a class="cta" href="/Begin-Your-Revolution.html">Talk to an AppSheet Consultant</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › AppSheet Consultant</div>
-    <h2>AppSheet with AI built in — when it's the right fit</h2>
-    <p>AppSheet is Google's no-code app platform. When it's built correctly — with AI automation layered in from the start — it replaces the spreadsheets, email threads, and manual handoffs your team is currently surviving on.</p>
+    <h2>AppSheet, engineered right — when it's the right fit</h2>
+    <p>AppSheet is Google's no-code app platform. When it's built correctly — with the data model, workflow, and permissions engineered from day one — it replaces the spreadsheets, email threads, and manual handoffs your team is currently surviving on.</p>
     <ul class="check-list">
       <li>Your team already uses Google Workspace — Sheets, Drive, Gmail, Calendar are already the stack</li>
       <li>Your current process lives in spreadsheets that are getting too big, too fragile, or too dependent on one person</li>
-      <li>You have field teams who need AI-assisted mobile access to job data, forms, and customer records</li>
-      <li>You need AI-managed approval workflows without paying enterprise software prices</li>
-      <li>You want a real AI-powered app fast — without a 6-month development project or an IT department</li>
+      <li>You have field teams who need mobile access to job data, forms, and customer records</li>
+      <li>You need real approval workflows without paying enterprise software prices</li>
+      <li>You want a working app fast — without a 6-month development project or an IT department</li>
     </ul>
   </section>
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>What we build with AppSheet — AI-powered from day one</h2>
+      <h2>What we build with AppSheet</h2>
       <div class="grid">
-        <div class="card"><h3>AI-Powered Custom Internal Apps</h3><p>Job trackers, AI-managed intake systems, inspection tools — built around your actual workflow, not someone else's template.</p></div>
-        <div class="card"><h3>AI-Generated Dashboards & Reports</h3><p>Live AI-powered views of what matters to your team — no manual export, no spreadsheet rebuild on Friday afternoon.</p></div>
-        <div class="card"><h3>AI-Validated Forms & Structured Inputs</h3><p>Replace free-form emails with AI-validated, structured data collection that's consistent every single time.</p></div>
-        <div class="card"><h3>AI-Triggered Workflow Automations</h3><p>AI-powered notifications, smart assignments, status updates, and reminders that fire automatically when things happen.</p></div>
-        <div class="card"><h3>AI-Personalized Role-Based Views</h3><p>Managers see everything. Field staff see their jobs. Clients see their projects. AI surfaces what each person needs.</p></div>
-        <div class="card"><h3>AppSheet + AI Assistant Integration</h3><p>AI layer on top — summarize updates, draft responses, flag anomalies — while the AppSheet system is the reliable foundation underneath.</p></div>
+        <div class="card"><h3>Custom Internal Apps</h3><p>Job trackers, intake systems, inspection tools — built around your actual workflow, not someone else's template.</p></div>
+        <div class="card"><h3>Dashboards & Reports</h3><p>Live views of what matters to your team — no manual export, no spreadsheet rebuild on Friday afternoon.</p></div>
+        <div class="card"><h3>Forms & Structured Inputs</h3><p>Replace free-form emails with structured, validated data collection that's consistent every single time.</p></div>
+        <div class="card"><h3>Engineered Workflow Automations</h3><p>Notifications, assignments, status updates, and reminders that fire automatically when things happen.</p></div>
+        <div class="card"><h3>Role-Based Views</h3><p>Managers see everything. Field staff see their jobs. Clients see their projects. Each person sees what they need.</p></div>
+        <div class="card"><h3>AppSheet + AI, When It Fits</h3><p>Where it adds real leverage — summaries, draft responses, anomaly flags — we layer it on top of a reliable AppSheet foundation. The system runs without it.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>Why an AI-experienced AppSheet consultant beats building it yourself</h2>
+    <h2>Why an experienced AppSheet consultant beats building it yourself</h2>
     <p>AppSheet is no-code — but the decisions underneath it are everything. A poorly structured data model creates the same problems as a bad spreadsheet, just harder and more expensive to fix.</p>
     <ul class="check-list">
-      <li>AI-ready data structure from day one — wrong tables mean the AI can't do its job and the app won't scale</li>
-      <li>Clean AI workflow logic — messy automations create more confusion than they solve, and AI amplifies both the good and the bad</li>
-      <li>AI-enforced permissions and security — planned from day one, not patched in after the first data incident</li>
-      <li>Mapped to your real AI-enhanced process — not an idealized version of it that nobody actually follows</li>
-      <li>We've built and deployed AI-powered AppSheet systems across multiple industries — we know what breaks and what scales</li>
+      <li>Engineered data structure from day one — wrong tables mean the app won't scale and reports won't add up</li>
+      <li>Clean workflow logic — messy automations create more confusion than they solve, and they're hardest to untangle later</li>
+      <li>Permissions and security planned from day one, not patched in after the first data incident</li>
+      <li>Mapped to your real process — not an idealized version of it that nobody actually follows</li>
+      <li>We've built and deployed AppSheet systems across multiple industries — we know what breaks and what scales</li>
     </ul>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Talk to an AppSheet Consultant Who Builds AI In From the Start</h2>
-      <p>Tell us what process you're trying to fix. We'll show you what a well-built AI-powered AppSheet system looks like — and whether it's the right tool for your exact situation.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <h2>Talk to an AppSheet Consultant Who Engineers the Whole System</h2>
+      <p>Tell us what process you're trying to fix. We'll show you what a well-engineered AppSheet system looks like — and whether it's the right tool for your exact situation. If it's not, we'll tell you that too.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
     <div class="internal-links">
       <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets →</a>
@@ -182,7 +182,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
       </div>
     </div>
   </footer>

--- a/custom-workflow-automation/index.html
+++ b/custom-workflow-automation/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Custom Workflow Automation for Small Business | YourOS</title>
-  <meta name="description" content="We turn scattered processes into clear, automated workflows your team can actually follow. Stop duct-taping tools together. Build a system that runs itself." />
+  <meta name="description" content="Growth Systems Engineering for service businesses. We turn scattered processes into clear workflow systems your team can actually follow — automated handoffs, owned next steps, visible status. Built to your constraints, not pulled off a shelf." />
   <link rel="canonical" href="https://www.youros.app/custom-workflow-automation/" />
   <link rel="alternate" type="text/markdown" href="/llms.txt">
   <meta name="robots" content="index, follow" />
   <meta property="og:title" content="Custom Workflow Automation for Small Business | YourOS" />
-  <meta property="og:description" content="We turn scattered processes into clear, automated workflows your team can actually follow. Stop duct-taping tools together. Build a system that runs itself." />
+  <meta property="og:description" content="Growth Systems Engineering for service businesses. We turn scattered processes into clear workflow systems your team can actually follow — automated handoffs, owned next steps, visible status. Built to your constraints, not pulled off a shelf." />
   <meta property="og:image" content="https://i.postimg.cc/Bnrbwc51/Your-OS-Logo.png" />
   <meta property="og:url" content="https://www.youros.app/custom-workflow-automation/" />
   <meta property="og:type" content="website" />
@@ -109,21 +109,21 @@
         <div class="dropdown-content"><a href="https://www.youros.app/what-does-youros-do/stories-and-testimony">Stories & Testimony</a></div>
       </div>
       <a href="/blog/">Blog</a>
-      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <a class="nav-cta-link" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
   </nav>
 
   <section class="hero">
-    <div class="hero-eyebrow">AI-Enhanced Workflow Automation</div>
-    <h1>Your Team's Chaos Has a Name. It's Called a Missing Workflow. We Fix That With AI.</h1>
-    <p>We build AI-enhanced custom workflows that serve your team — automated handoffs, AI-managed notifications, and real-time status visibility that lets your people focus on the work that actually needs them, not on tracking down where things stand.</p>
+    <div class="hero-eyebrow">Growth Systems Engineering</div>
+    <h1>Your Team's Chaos Has a Name. It's Called a Missing Workflow. We Engineer One That Fits.</h1>
+    <p>We build custom workflow systems that serve your team — automated handoffs, owned next steps, and real-time status visibility that lets your people focus on the work that actually needs them, not on tracking down where things stand.</p>
     <a class="cta" href="/Begin-Your-Revolution.html">Show Us the Workflow Breaking Your Team</a>
   </section>
 
   <section class="section wrapper">
     <div class="breadcrumb"><a href="/">Home</a> › Custom Workflow Automation</div>
     <h2>Signs your broken workflow is costing you more than you think</h2>
-    <p>Most businesses accept the chaos as normal — until they see an AI-powered workflow running alongside it. Then the cost of waiting becomes obvious.</p>
+    <p>Most businesses accept the chaos as normal — until they see a real workflow system running alongside it. Then the cost of waiting becomes obvious.</p>
     <ul class="check-list">
       <li>Work falls through the cracks between tools, people, or inboxes every week</li>
       <li>Approvals live in email threads that never get read — or get read too late</li>
@@ -136,35 +136,35 @@
 
   <section class="section" style="background:var(--bg-alt);border-top:1px solid rgba(255,255,255,.06);border-bottom:1px solid rgba(255,255,255,.06);">
     <div class="wrapper">
-      <h2>What an AI-powered custom workflow does instead</h2>
+      <h2>What a real workflow system does instead</h2>
       <div class="grid">
-        <div class="card"><h3>AI-Assigned Ownership</h3><p>No ambiguity about who does what. The AI-powered system assigns, notifies, and tracks — so nobody can say they didn't know it was their job.</p></div>
-        <div class="card"><h3>AI-Driven Work Handoffs</h3><p>When step one completes, step two starts automatically. AI-triggered handoffs mean no dropped balls, no manual nudges.</p></div>
-        <div class="card"><h3>One Source of AI-Managed Truth</h3><p>Enter data once, see it everywhere. AI ends re-entry, version confusion, and the "which spreadsheet is current?" conversation for good.</p></div>
-        <div class="card"><h3>AI-Powered Status Visibility</h3><p>Anyone can check where something stands without asking a person — because the AI-powered system always knows and shows it.</p></div>
-        <div class="card"><h3>AI-Triggered Deadline Alerts</h3><p>AI flags approaching deadlines and overdue items before they become emergencies — without a manager chasing anyone.</p></div>
-        <div class="card"><h3>AI-Generated Reports</h3><p>Live dashboards and AI-generated summaries pull from real data — not from someone rebuilding a spreadsheet on their worst day of the week.</p></div>
+        <div class="card"><h3>Clear Ownership at Every Step</h3><p>No ambiguity about who does what. The system assigns, notifies, and tracks — so nobody can say they didn't know it was their job.</p></div>
+        <div class="card"><h3>Automated Work Handoffs</h3><p>When step one completes, step two starts. Engineered handoffs mean no dropped balls, no manual nudges, no "did anyone tell Jen?"</p></div>
+        <div class="card"><h3>One Source of Truth</h3><p>Enter data once, see it everywhere. The system ends re-entry, version confusion, and the "which spreadsheet is current?" conversation for good.</p></div>
+        <div class="card"><h3>Status Visible to Everyone</h3><p>Anyone can check where something stands without asking a person — because the system always knows and shows it.</p></div>
+        <div class="card"><h3>Deadlines That Catch Themselves</h3><p>The system flags approaching deadlines and overdue items before they become emergencies — without a manager chasing anyone.</p></div>
+        <div class="card"><h3>Reports Built From Real Data</h3><p>Live dashboards and summaries pull from the actual work — not from someone rebuilding a spreadsheet on their worst day of the week.</p></div>
       </div>
     </div>
   </section>
 
   <section class="section wrapper">
-    <h2>AI-enhanced workflows we build for small teams</h2>
+    <h2>Workflow systems we engineer for small teams</h2>
     <ul class="check-list">
-      <li>AI-assisted customer onboarding — from first contact to fully set up, without a single manual handoff</li>
-      <li>AI-managed service request handling — intake, assignment, status tracking, and completion sign-off, automated</li>
-      <li>AI-powered job and project tracking — where every job is, who owns it, what's due, visible to everyone</li>
-      <li>AI-routed internal approvals — requests routed, approved, and logged without living in anyone's email</li>
-      <li>AI-generated weekly reporting — data collected and summarized automatically, delivered on schedule</li>
-      <li>AI-managed follow-up sequences — nothing falls through because AI doesn't forget to send the email</li>
+      <li>Customer onboarding — from first contact to fully set up, without a single manual handoff</li>
+      <li>Service request handling — intake, assignment, status tracking, and completion sign-off, automated end-to-end</li>
+      <li>Job and project tracking — where every job is, who owns it, what's due, visible to everyone who needs to know</li>
+      <li>Internal approvals — requests routed, approved, and logged without living in anyone's email</li>
+      <li>Weekly reporting — data collected and summarized automatically, delivered on schedule</li>
+      <li>Follow-up sequences — nothing falls through because the system doesn't forget to send the email</li>
     </ul>
   </section>
 
   <section class="section wrapper">
     <div class="cta-block">
-      <h2>Tell Us the Workflow That's Costing You the Most. We'll Fix It With AI.</h2>
-      <p>In one focused session, we map the broken process, surface the AI-automation opportunities, and show you exactly what a working system looks like — and how fast we can build it.</p>
-      <a class="cta" href="/Begin-Your-Revolution.html">Book a Free Strategy Session</a>
+      <h2>Tell Us the Workflow That's Costing You the Most. We'll Engineer the Fix.</h2>
+      <p>In one focused conversation, we map the broken process, surface the leverage points, and show you exactly what a working system looks like — and how fast we can build it.</p>
+      <a class="cta" href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
     </div>
     <div class="internal-links">
       <a href="/replace-spreadsheets-with-custom-app/">Replace Spreadsheets →</a>
@@ -183,7 +183,7 @@
         <a href="/custom-workflow-automation/">Workflow Automation</a>
         <a href="/appsheet-consultant/">AppSheet Consulting</a>
         <a href="/security-trust.html">Security</a>
-        <a href="/Begin-Your-Revolution.html">Book a Strategy Session</a>
+        <a href="/Begin-Your-Revolution.html">Start a Growth Conversation</a>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## Summary

Rewrites the four OFF-message landing pages flagged in the 2026-06-16 message audit to lock in GSE (Growth Systems Engineering) positioning across the SEO funnel.

- `custom-workflow-automation/` — H1 reframed from "We Fix That With AI" → "We Engineer One That Fits"; AI-Powered/Driven/Managed prefixes stripped from cards and check-lists
- `appsheet-consultant/` — AppSheet positioned as one of our engineering tools, not "AI-Powered AppSheet"; added honest closer ("if it's not the right tool, we'll tell you that")
- `ai-automation-services-small-business/` — removes the doctrine-violating "Good AI-powered automation doesn't replace your team" line (planted the AI-replaces-team frame to dismiss it); engineered system is the protagonist throughout
- `ai-assistants-for-business/` — buzzword overload removed; the strong "build the foundation first, then add AI where it earns its place" spine made explicit as GSE applied to AI

All four pages: `Start a Growth Conversation` replaces `Book a Free Strategy Session` across nav, hero, CTA block, and footer to match home.

## What's not in this PR

- 🔧 Scope #3 (utah-ai-automation local rebuild) — deferred until Xavier's reworked SEO numbers come in
- 🔧 Site-wide footer/CTA standardization on the other 14+ pages — separate cleanup PR
- 📊 Reworked SEO scorecard data — blocked on GA4 + Search Console API access for sjonesapps@gmail.com

## Test plan

- [ ] `/custom-workflow-automation/` reads as GSE, not AI-as-protagonist
- [ ] `/appsheet-consultant/` reads as practical engineering, AI mentioned only where it earns its place
- [ ] `/ai-automation-services-small-business/` H1 is now "Work Your Business Could Engineer Away"; no "doesn't replace your team" phrasing remains
- [ ] `/ai-assistants-for-business/` still ranks for "AI assistants" SEO term but reads system-first, not buzzword-first
- [ ] All four pages: nav, hero CTA, CTA block, and footer all say "Start a Growth Conversation"
- [ ] `<link rel="alternate" type="text/markdown" href="/llms.txt">` from PR #64 still present on all four (preserved in rebase)
- [ ] No 404s on internal `/lets-talk-ai*` references (already killed in PR #64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)